### PR TITLE
Added Attribution and TTL support (2.0.0)

### DIFF
--- a/AppsOnAir-AppLink.podspec
+++ b/AppsOnAir-AppLink.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
 
   s.name             = 'AppsOnAir-AppLink'
-  s.version          = '1.4.1'
+  s.version          = '2.0.0'
   s.summary          = 'AppLink service for app download tracking, deep linking, and engagement analytics for ios - an alternative to Firebase Dynamic Links'
   s.homepage         = 'https://documentation.appsonair.com/category/applink/'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/AppsOnAir_AppLink/AppConst.swift
+++ b/AppsOnAir_AppLink/AppConst.swift
@@ -81,4 +81,15 @@ let attributionStatusNonOrganic = "non-organic"
 
 let statusCodeKey = "statusCode"
 
+let successStatusCode = 200
+
 let dataKey = "data"
+
+//MARK: - Internal Notifications
+
+extension Notification.Name {
+    /// Posted when the app returns to foreground after having been genuinely backgrounded
+    /// (not the initial cold-start activation), and `isFirstLaunch` flips from `true` to `false`.
+    static let appsOnAirFirstLaunchDidExpire = Notification.Name(
+        "AppsOnAirAppLink.firstLaunchDidExpire")
+}

--- a/AppsOnAir_AppLink/AppConst.swift
+++ b/AppsOnAir_AppLink/AppConst.swift
@@ -104,6 +104,15 @@ let applinkClickTimeParam = "applink_click_time"
 /// matches the Android SDK's stored key.
 let clickTimeStorageKey = "click_time"
 
+/// HTTP response header carrying the server clock, used to correct the device clock.
+let dateHeader = "Date"
+
+/// UserDefaults keys for the server-time correction. Both match the Android SDK's stored keys.
+/// The offset is `serverTime - deviceTime` at the last capture, in seconds; the high-water mark is
+/// the newest corrected time ever observed, used to detect a clock wound backwards.
+let serverTimeOffsetStorageKey = "server_time_offset"
+let serverTimeHighWaterStorageKey = "server_time_high_water"
+
 /// Response field carrying the AppsFlyer attribution object. Exposed only through the newer
 /// attribution surface, so it is stripped from the deprecated referral payloads.
 let appsFlyerKey = "appsFlyer"

--- a/AppsOnAir_AppLink/AppConst.swift
+++ b/AppsOnAir_AppLink/AppConst.swift
@@ -16,9 +16,10 @@ let referralSuccessFully = "Referral SuccessFully"
 
 let clipboardEmpty = "Clipboard is empty"
 
-let invalidBundleIdentifier  = "Invalid bundle identifier"
+let invalidBundleIdentifier = "Invalid bundle identifier"
 
-let enableAdvancedDeferredLinkDisabled = "EnableAdvancedDeferredLink is disabled/does not exist in Info.plist"
+let enableAdvancedDeferredLinkDisabled =
+    "EnableAdvancedDeferredLink is disabled/does not exist in Info.plist"
 
 let notFoundBundle = "not found or missing bundle identifier"
 
@@ -61,3 +62,23 @@ let isFirstOpenKey = "isFirstOpen"
 let isReferralKey = "isUserReferral"
 
 let EnableAdvancedDeferredLinkKey = "EnableAdvancedDeferredLink"
+
+let isConsumedKey = "isConsumed"
+
+let isFirstLaunchKey = "isFirstLaunch"
+
+let firstInstallTimeKey = "firstInstallTime"
+
+let attributionStatusKey = "attributionStatus"
+
+let attributionTtlResponseKey = "attributionTtl"
+
+let applinkClickTimeParam = "applink_click_time"
+
+let attributionStatusOrganic = "organic"
+
+let attributionStatusNonOrganic = "non-organic"
+
+let statusCodeKey = "statusCode"
+
+let dataKey = "data"

--- a/AppsOnAir_AppLink/AppConst.swift
+++ b/AppsOnAir_AppLink/AppConst.swift
@@ -57,6 +57,26 @@ let url = "URL"
 
 let xApplicationId = "x-application-key"
 
+/// Sent on every API request so the backend can attribute behaviour to an SDK release.
+let xSdkVersion = "x-sdk-version"
+
+/// Pod name handed to `SdkManager.getVersion(for:)`, used only as a fallback.
+let appLinkSdkName = "AppsOnAir-AppLink"
+
+/// Name of the resource bundle CocoaPods builds from `s.resource_bundles`. Its
+/// `CFBundleShortVersionString` is the version reported in `x-sdk-version`, so
+/// `Resources/AppsOnAir-AppLinkInfo.plist` must stay in step with `s.version` in the podspec.
+/// SwiftPM names its bundle `<Package>_<Target>.bundle` instead, which is why it is reached
+/// through `Bundle.module` rather than by name.
+let appLinkResourceBundleName = "AppsOnAir_AppLink"
+
+/// The plist shipped inside that bundle. SwiftPM writes its own `Info.plist` without a version, so
+/// this file is the only version source under SPM and must track `s.version` in the podspec.
+/// Under CocoaPods the bundle's own `Info.plist` is stamped from `s.version` and wins.
+let appLinkInfoPlistName = "AppsOnAir-AppLinkInfo"
+
+let shortVersionKey = "CFBundleShortVersionString"
+
 let isFirstOpenKey = "isFirstOpen"
 
 let isReferralKey = "isUserReferral"
@@ -71,9 +91,22 @@ let firstInstallTimeKey = "firstInstallTime"
 
 let attributionStatusKey = "attributionStatus"
 
+/// UserDefaults key for the persisted attribution status. Distinct from `attributionStatusKey`,
+/// which names the field inside the response payload; matches the Android SDK's stored key.
+let attributionStatusStorageKey = "attribution_status"
+
 let attributionTtlResponseKey = "attributionTtl"
 
 let applinkClickTimeParam = "applink_click_time"
+
+/// UserDefaults key for the persisted clipboard click time. Distinct from `applinkClickTimeParam`,
+/// which names both the clipboard query item and the field inside the response payload;
+/// matches the Android SDK's stored key.
+let clickTimeStorageKey = "click_time"
+
+/// Response field carrying the AppsFlyer attribution object. Exposed only through the newer
+/// attribution surface, so it is stripped from the deprecated referral payloads.
+let appsFlyerKey = "appsFlyer"
 
 let attributionStatusOrganic = "organic"
 

--- a/AppsOnAir_AppLink/AppHelper.swift
+++ b/AppsOnAir_AppLink/AppHelper.swift
@@ -26,9 +26,9 @@ import Foundation
         /// `false` this session by default; flips to `true` only starting the next launch after a successful referral fetch.
         internal var isConsumed: Bool = false
 
-        /// Device's first install time, computed fresh on every access (not cached).
-        internal var firstInstallTime: String {
-            getAppInstallationDate()
+        /// Device's first install time
+        internal var firstInstallTime: String? {
+            return getAppInstallationDateEpoch()
         }
 
         // MARK: - Use Get User Agent
@@ -36,14 +36,54 @@ import Foundation
 
         private var webView: WKWebView = WKWebView(frame: .zero)
 
+        /// `true` when `isAppFirstOpen` just flipped, so the next `didBecomeActive` notifies listeners.
+        private var firstLaunchExpired: Bool = false
+
         // MARK: - Initializer
 
         private override init() {
             super.init()
             handleAppLaunch()
+            observeAppLifecycleNotifications()
+        }
+
+        deinit {
+            NotificationCenter.default.removeObserver(self)
         }
 
         // MARK: - App Lifecycle
+
+        private func observeAppLifecycleNotifications() {
+            // handleAppDidEnterBackground() -> Called when the app enters the background.
+            // handleAppDidBecomeActive() -> Called on launch and when returning to the foreground.
+            NotificationCenter.default.addObserver(
+                self, selector: #selector(handleAppDidEnterBackground),
+                name: UIApplication.didEnterBackgroundNotification, object: nil)
+            NotificationCenter.default.addObserver(
+                self, selector: #selector(handleAppDidBecomeActive),
+                name: UIApplication.didBecomeActiveNotification, object: nil)
+        }
+
+        @objc private func handleAppDidEnterBackground() {
+            Logger.logInternal(
+                "AppHelper: didEnterBackground — isAppFirstOpen=\(isAppFirstOpen)")
+            guard isAppFirstOpen else { return }
+            isAppFirstOpen = false
+            firstLaunchExpired = true
+            Logger.logInternal(
+                "AppHelper: isAppFirstOpen flipped to false, will notify on next didBecomeActive")
+        }
+
+        @objc private func handleAppDidBecomeActive() {
+            Logger.logInternal(
+                "AppHelper: didBecomeActive — firstLaunchExpired=\(firstLaunchExpired)"
+            )
+            guard firstLaunchExpired else { return }
+            firstLaunchExpired = false
+            Logger.logInternal(
+                "AppHelper: posting appsOnAirFirstLaunchDidExpire")
+            NotificationCenter.default.post(name: .appsOnAirFirstLaunchDidExpire, object: nil)
+        }
 
         /// handle to get String from clipboard
         internal func readClipBoard() -> String? {
@@ -76,38 +116,26 @@ import Foundation
             }
         }
 
-        /// Formats a Date using the device's current timezone, matching AppsOnAir-Core's format.
-        internal func formatDateToDeviceTimeZone(_ date: Date) -> String {
-            let formatter = DateFormatter()
+        /// Fetches the app's first install date from the Documents directory's creation date,
+        internal func getAppInstallationDateValue() -> Date? {
+            guard
+                let docPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+                    .first?.path
+            else {
+                return nil
+            }
 
-            // Use device's current timezone
-            formatter.timeZone = TimeZone.current
-
-            // Use consistent month abbreviations
-            formatter.locale = Locale(identifier: "en_US_POSIX")
-
-            // Force 12-hour format with AM/PM
-            formatter.dateFormat = "dd-MMM-yyyy hh:mm:ss a"
-
-            return formatter.string(from: date)
+            do {
+                let attributes = try FileManager.default.attributesOfItem(atPath: docPath)
+                return attributes[.creationDate] as? Date
+            } catch {
+                return nil
+            }
         }
 
-        /// Fetches the app's first install date from the Documents directory's creation date,
-        /// matching AppsOnAir-Core's `getAppInstallationDate()` implementation.
-        internal func getAppInstallationDate() -> String {
-            if let docPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
-                .first?.path
-            {
-                do {
-                    let attributes = try FileManager.default.attributesOfItem(atPath: docPath)
-                    if let installationDate = attributes[.creationDate] as? Date {
-                        return formatDateToDeviceTimeZone(installationDate)
-                    }
-                } catch {
-                    return "Unavailable"
-                }
-            }
-            return "Unavailable"
+        /// App install date in epoch seconds.
+        internal func getAppInstallationDateEpoch() -> String? {
+            getAppInstallationDateValue()?.timeIntervalSince1970.description
         }
 
         // MARK: - Keychain Handling

--- a/AppsOnAir_AppLink/AppHelper.swift
+++ b/AppsOnAir_AppLink/AppHelper.swift
@@ -92,7 +92,8 @@ import Foundation
 
         private var webView: WKWebView = WKWebView(frame: .zero)
 
-        /// `true` when `isAppFirstOpen` just flipped, so the next `didBecomeActive` notifies listeners.
+        /// Set when backgrounding ends the first launch, and cleared by the `didBecomeActive` that
+        /// follows. One-shot, so the attribution payload is re-delivered exactly once.
         private var firstLaunchExpired: Bool = false
 
         // MARK: - Initializer
@@ -123,6 +124,9 @@ import Foundation
         @objc private func handleAppDidEnterBackground() {
             Logger.logInternal(
                 "AppHelper: didEnterBackground — isAppFirstOpen=\(isAppFirstOpen)")
+
+            // Leaving the foreground ends the first launch, so `isFirstLaunch` turns false
+            // without waiting for the process to restart.
             guard isAppFirstOpen else { return }
             isAppFirstOpen = false
             firstLaunchExpired = true
@@ -134,6 +138,8 @@ import Foundation
             Logger.logInternal(
                 "AppHelper: didBecomeActive — firstLaunchExpired=\(firstLaunchExpired)"
             )
+            // One-shot: only the activation that follows `isFirstLaunch` expiring posts. Later
+            // returns to the foreground read the same persisted state, so they carry nothing new.
             guard firstLaunchExpired else { return }
             firstLaunchExpired = false
             Logger.logInternal(
@@ -194,6 +200,62 @@ import Foundation
         internal func updateClickTime(_ value: TimeInterval) {
             clickTime = value
             userDefaults.set(value, forKey: clickTimeStorageKey)
+        }
+
+        // MARK: - Server Time Correction
+
+        /// Parses the RFC 1123 form HTTP requires for `Date`. Static so the formatter is built once;
+        /// `DateFormatter` is expensive and this runs on every API response.
+        private static let httpDateFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(identifier: "GMT")
+            formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+            return formatter
+        }()
+
+        /// `serverTime - deviceTime` at the last capture, in seconds. Zero until a response has
+        /// been seen, which makes `correctedNow` fall back to the plain device clock.
+        private var serverTimeOffset: TimeInterval {
+            get { userDefaults.double(forKey: serverTimeOffsetStorageKey) }
+            set { userDefaults.set(newValue, forKey: serverTimeOffsetStorageKey) }
+        }
+
+        /// The newest corrected time ever observed. Real time only moves forward, so a corrected
+        /// now behind this mark means the clock was wound back between two observations.
+        private var serverTimeHighWater: TimeInterval {
+            get { userDefaults.double(forKey: serverTimeHighWaterStorageKey) }
+            set { userDefaults.set(newValue, forKey: serverTimeHighWaterStorageKey) }
+        }
+
+        /// The device clock corrected by the last known server offset.
+        internal var correctedNow: TimeInterval {
+            Date().timeIntervalSince1970 + serverTimeOffset
+        }
+
+        /// True when corrected time has moved behind the newest time already observed.
+        internal var hasClockRewound: Bool {
+            let highWater = serverTimeHighWater
+            return highWater > 0 && correctedNow < highWater
+        }
+
+        /// Advances the high-water mark. Never moves it backwards.
+        internal func observeCorrectedTime(_ corrected: TimeInterval) {
+            if corrected > serverTimeHighWater {
+                serverTimeHighWater = corrected
+            }
+        }
+
+        /// Records the server clock from a response `Date` header. Called for every API response,
+        /// so an absent or malformed header is ignored rather than logged loudly.
+        internal func recordServerDate(_ header: String?) {
+            guard let header,
+                let serverDate = AppHelper.httpDateFormatter.date(from: header)
+            else { return }
+
+            let serverSeconds = serverDate.timeIntervalSince1970
+            serverTimeOffset = serverSeconds - Date().timeIntervalSince1970
+            observeCorrectedTime(serverSeconds)
         }
 
         /// Fetches the app's first install date from the Documents directory's creation date,

--- a/AppsOnAir_AppLink/AppHelper.swift
+++ b/AppsOnAir_AppLink/AppHelper.swift
@@ -23,6 +23,14 @@ import Foundation
         internal var isAppFirstOpen: Bool = false
         internal var isUserReferral: Bool = false
 
+        /// `false` this session by default; flips to `true` only starting the next launch after a successful referral fetch.
+        internal var isConsumed: Bool = false
+
+        /// Device's first install time, computed fresh on every access (not cached).
+        internal var firstInstallTime: String {
+            getAppInstallationDate()
+        }
+
         // MARK: - Use Get User Agent
         /// A WKWebView instance used to retrieve the user agent.
 
@@ -58,6 +66,48 @@ import Foundation
             if isAppFirstOpen {
                 userDefaults.set(true, forKey: isFirstOpenKey)
             }
+
+            // isConsumed: use the cached value if it exists, otherwise create it with the default (false)
+            if userDefaults.object(forKey: isConsumedKey) != nil {
+                isConsumed = userDefaults.bool(forKey: isConsumedKey)
+            } else {
+                isConsumed = false
+                userDefaults.set(false, forKey: isConsumedKey)
+            }
+        }
+
+        /// Formats a Date using the device's current timezone, matching AppsOnAir-Core's format.
+        internal func formatDateToDeviceTimeZone(_ date: Date) -> String {
+            let formatter = DateFormatter()
+
+            // Use device's current timezone
+            formatter.timeZone = TimeZone.current
+
+            // Use consistent month abbreviations
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+
+            // Force 12-hour format with AM/PM
+            formatter.dateFormat = "dd-MMM-yyyy hh:mm:ss a"
+
+            return formatter.string(from: date)
+        }
+
+        /// Fetches the app's first install date from the Documents directory's creation date,
+        /// matching AppsOnAir-Core's `getAppInstallationDate()` implementation.
+        internal func getAppInstallationDate() -> String {
+            if let docPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+                .first?.path
+            {
+                do {
+                    let attributes = try FileManager.default.attributesOfItem(atPath: docPath)
+                    if let installationDate = attributes[.creationDate] as? Date {
+                        return formatDateToDeviceTimeZone(installationDate)
+                    }
+                } catch {
+                    return "Unavailable"
+                }
+            }
+            return "Unavailable"
         }
 
         // MARK: - Keychain Handling

--- a/AppsOnAir_AppLink/AppHelper.swift
+++ b/AppsOnAir_AppLink/AppHelper.swift
@@ -26,9 +26,65 @@ import Foundation
         /// `false` this session by default; flips to `true` only starting the next launch after a successful referral fetch.
         internal var isConsumed: Bool = false
 
-        /// Device's first install time
-        internal var firstInstallTime: String? {
-            return getAppInstallationDateEpoch()
+        /// Resolved attribution status (organic/non-organic). Restored from UserDefaults on launch
+        /// and re-persisted through `updateAttributionStatus(_:)` on every resolution, so launch 2+
+        /// reports the value resolved on first launch without needing a referral fetch.
+        internal private(set) var attributionStatus: String = attributionStatusOrganic
+
+        /// Clipboard `applink_click_time`, in epoch milliseconds. Restored from UserDefaults on
+        /// launch and re-persisted through `updateClickTime(_:)`, so it keeps reaching the
+        /// attribution payload on later launches — the clipboard is only read once, on first open.
+        /// `nil` until a deferred link carrying the param has been read.
+        internal private(set) var clickTime: TimeInterval?
+
+        /// SDK version reported in the `x-sdk-version` header.
+        ///
+        /// Read from this SDK's own resource bundle rather than relying on `SdkManager`'s bundle
+        /// heuristics, which only recognise the CocoaPods bundle name — SwiftPM names its bundle
+        /// `<Package>_<Target>.bundle`, so `Bundle.module` is the only dependable handle there.
+        /// Note `Bundle(for:)` alone is not enough under CocoaPods: with static linking this class
+        /// lives in the app binary, so that returns the *host app's* version.
+        /// Falls back to `SdkManager` (which covers framework-based installs), then to "-".
+        internal var sdkVersion: String {
+            #if SWIFT_PACKAGE
+                let resourceBundle: Bundle? = .module
+            #else
+                let hostBundle = Bundle(for: AppHelper.self)
+                let resourceBundle =
+                    hostBundle.url(forResource: appLinkResourceBundleName, withExtension: "bundle")
+                    .flatMap { Bundle(url: $0) }
+                    ?? Bundle.main.url(
+                        forResource: appLinkResourceBundleName, withExtension: "bundle"
+                    ).flatMap { Bundle(url: $0) }
+            #endif
+
+            // CocoaPods stamps the bundle's own Info.plist from s.version, so it cannot drift.
+            if let version = resourceBundle?
+                .object(forInfoDictionaryKey: shortVersionKey) as? String,
+                !version.isEmpty
+            {
+                return version
+            }
+
+            // SwiftPM writes its own Info.plist with no version, so read the plist we ship inside
+            // the bundle — the only version source on that path.
+            if let plistURL = resourceBundle?.url(
+                forResource: appLinkInfoPlistName, withExtension: "plist"),
+                let data = try? Data(contentsOf: plistURL),
+                let plist = try? PropertyListSerialization.propertyList(
+                    from: data, options: [], format: nil) as? [String: Any],
+                let version = plist[shortVersionKey] as? String,
+                !version.isEmpty
+            {
+                return version
+            }
+
+            return SdkManager.shared.getVersion(for: appLinkSdkName)
+        }
+
+        /// Device's first install time, as epoch milliseconds.
+        internal var firstInstallTime: Int64? {
+            return getAppInstallationDateEpochMilliseconds()
         }
 
         // MARK: - Use Get User Agent
@@ -114,6 +170,30 @@ import Foundation
                 isConsumed = false
                 userDefaults.set(false, forKey: isConsumedKey)
             }
+
+            // attributionStatus: restore the last resolved value; organic only when nothing stored yet
+            attributionStatus =
+                userDefaults.string(forKey: attributionStatusStorageKey) ?? attributionStatusOrganic
+
+            Logger.logInternal("attributionStatus restored: \(attributionStatus)")
+
+            // clickTime: restore the stored value; 0 means nothing has been stored yet
+            let storedClickTime = userDefaults.double(forKey: clickTimeStorageKey)
+            clickTime = storedClickTime > 0 ? storedClickTime : nil
+
+            Logger.logInternal("clickTime restored: \(String(describing: clickTime))")
+        }
+
+        /// Caches and persists a newly resolved attribution status so later launches report it.
+        internal func updateAttributionStatus(_ status: String) {
+            attributionStatus = status
+            userDefaults.set(status, forKey: attributionStatusStorageKey)
+        }
+
+        /// Caches and persists the clipboard click time so later launches keep reporting it.
+        internal func updateClickTime(_ value: TimeInterval) {
+            clickTime = value
+            userDefaults.set(value, forKey: clickTimeStorageKey)
         }
 
         /// Fetches the app's first install date from the Documents directory's creation date,
@@ -133,9 +213,15 @@ import Foundation
             }
         }
 
-        /// App install date in epoch seconds.
-        internal func getAppInstallationDateEpoch() -> String? {
-            getAppInstallationDateValue()?.timeIntervalSince1970.description
+        /// App install date in epoch milliseconds, matching the Android SDK's unit.
+        internal func getAppInstallationDateEpochMilliseconds() -> Int64? {
+            guard let installDate = getAppInstallationDateValue() else { return nil }
+
+            let milliseconds = Measurement(
+                value: installDate.timeIntervalSince1970, unit: UnitDuration.seconds
+            ).converted(to: .milliseconds).value
+
+            return Int64(milliseconds.rounded())
         }
 
         // MARK: - Keychain Handling

--- a/AppsOnAir_AppLink/AppLinkApiService.swift
+++ b/AppsOnAir_AppLink/AppLinkApiService.swift
@@ -59,6 +59,9 @@ import Foundation
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.setValue(appsOnAirCoreServices.appId, forHTTPHeaderField: xApplicationId)
+            request.setValue(
+                appHelper.sdkVersion,
+                forHTTPHeaderField: xSdkVersion)
 
             // Building JSON object
             var shortLinkData: [String: Any] = [:]
@@ -160,6 +163,9 @@ import Foundation
                 request.setValue(linkUserAgent, forHTTPHeaderField: userAgent)
                 request.setValue("application/json", forHTTPHeaderField: contentType)
                 request.setValue(appsOnAirCoreServices.appId, forHTTPHeaderField: xApplicationId)
+                request.setValue(
+                    appHelper.sdkVersion,
+                    forHTTPHeaderField: xSdkVersion)
 
                 if isEnableAdvancedDeferredLink {
                     request.httpMethod = "POST"
@@ -228,6 +234,9 @@ import Foundation
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.setValue(appsOnAirCoreServices.appId, forHTTPHeaderField: xApplicationId)
+            request.setValue(
+                appHelper.sdkVersion,
+                forHTTPHeaderField: xSdkVersion)
 
             let apiShortLinkPassData: [String: Any] = [
                 "shortId": shortId as Any,
@@ -299,6 +308,9 @@ import Foundation
             request.httpMethod = "GET"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.setValue(appsOnAirCoreServices.appId, forHTTPHeaderField: "x-application-key")
+            request.setValue(
+                appHelper.sdkVersion,
+                forHTTPHeaderField: xSdkVersion)
 
             networkSession.dataTask(with: request) { responseData, response, error in
                 Logger.logInternal("\(String(describing: url)) = \(linkURL)")

--- a/AppsOnAir_AppLink/AppLinkApiService.swift
+++ b/AppsOnAir_AppLink/AppLinkApiService.swift
@@ -114,6 +114,8 @@ import Foundation
                 Logger.logInternal("\(String(describing: url)) = \(generateShortLink)")
 
                 let httpResponse = response as? HTTPURLResponse
+                // Server clock, used to keep attributionTtl off the editable device clock.
+                appHelper.recordServerDate(httpResponse?.value(forHTTPHeaderField: dateHeader))
 
                 let statusCode = httpResponse?.statusCode
                 do {
@@ -179,6 +181,8 @@ import Foundation
                     Logger.logInternal("\(String(describing: url)) = \(getReferralLink)")
 
                     let httpResponse = response as? HTTPURLResponse
+                    // Server clock, used to keep attributionTtl off the editable device clock.
+                    appHelper.recordServerDate(httpResponse?.value(forHTTPHeaderField: dateHeader))
 
                     let statusCode = httpResponse?.statusCode
                     do {
@@ -255,6 +259,8 @@ import Foundation
                 Logger.logInternal("\(String(describing: url)) = \(generateShortLink)")
 
                 let httpResponse = response as? HTTPURLResponse
+                // Server clock, used to keep attributionTtl off the editable device clock.
+                appHelper.recordServerDate(httpResponse?.value(forHTTPHeaderField: dateHeader))
 
                 let statusCode = httpResponse?.statusCode
                 do {
@@ -320,6 +326,8 @@ import Foundation
                     completion([errorStr: errorSomeThingWrong])
                     return
                 }
+                // Server clock, used to keep attributionTtl off the editable device clock.
+                appHelper.recordServerDate(httpResponse.value(forHTTPHeaderField: dateHeader))
 
                 let statusCode = httpResponse.statusCode
                 do {

--- a/AppsOnAir_AppLink/AppLinkApiService.swift
+++ b/AppsOnAir_AppLink/AppLinkApiService.swift
@@ -40,6 +40,7 @@ import Foundation
             isOpenInBrowserAndroid: Bool? = nil,
             androidFallbackUrl: String? = nil,
             appsFlyer: [String: Any]? = nil,
+            attributionTtl: Int? = nil,
             completion: @escaping ([String: Any]) -> Void
         ) {
 
@@ -90,6 +91,11 @@ import Foundation
             //AppsFlyer attribution params
             if let appsFlyer = appsFlyer, !appsFlyer.isEmpty {
                 shortLinkData["appsFlyer"] = appsFlyer
+            }
+
+            //Attribution TTL
+            if let attributionTtl = attributionTtl {
+                shortLinkData["attributionTtl"] = attributionTtl
             }
 
             let apiShortLinkPassData: [String: Any] = [
@@ -171,7 +177,9 @@ import Foundation
                     let statusCode = httpResponse?.statusCode
                     do {
                         guard let responseData = responseData, !responseData.isEmpty else {
-                            completion([errorStr: errorSomeThingWrong])
+                            completion([
+                                errorStr: errorSomeThingWrong, statusCodeKey: statusCode as Any,
+                            ])
                             return
                         }
 
@@ -180,16 +188,19 @@ import Foundation
                         if statusCode == 429 {
                             let errorMessage = String(data: responseData, encoding: .utf8) ?? ""
                             Logger.logInfo(errorMessage, prefix: appsOnAirLink)
-                            completion([errorStr: errorMessage])
-                        } else if let json = try JSONSerialization.jsonObject(
+                            completion([errorStr: errorMessage, statusCodeKey: statusCode as Any])
+                        } else if var json = try JSONSerialization.jsonObject(
                             with: responseData, options: []) as? [String: Any]
                         {
+                            json[statusCodeKey] = statusCode
                             Logger.logInternal("\(responseJson) \(json)")
                             completion(json)
                         }
                     } catch {
                         Logger.logInternal("\(errorFailedToLoad) \(error.localizedDescription)")
-                        completion([errorStr: errorSomeThingWrong])
+                        completion([
+                            errorStr: errorSomeThingWrong, statusCodeKey: statusCode as Any,
+                        ])
                     }
 
                 }.resume()

--- a/AppsOnAir_AppLink/AppLinkApiService.swift
+++ b/AppsOnAir_AppLink/AppLinkApiService.swift
@@ -39,6 +39,7 @@ import Foundation
             isOpenInAndroidApp: Bool? = nil,
             isOpenInBrowserAndroid: Bool? = nil,
             androidFallbackUrl: String? = nil,
+            appsFlyer: [String: Any]? = nil,
             completion: @escaping ([String: Any]) -> Void
         ) {
 
@@ -84,6 +85,11 @@ import Foundation
             shortLinkData["isOpenInAndroidApp"] = isOpenInAndroidApp
             if let customUrlForAndroid = androidFallbackUrl {
                 shortLinkData["customUrlForAndroid"] = customUrlForAndroid
+            }
+
+            //AppsFlyer attribution params
+            if let appsFlyer = appsFlyer, !appsFlyer.isEmpty {
+                shortLinkData["appsFlyer"] = appsFlyer
             }
 
             let apiShortLinkPassData: [String: Any] = [

--- a/AppsOnAir_AppLink/AppLinkService.swift
+++ b/AppsOnAir_AppLink/AppLinkService.swift
@@ -95,6 +95,9 @@ import Combine
             if let firstLaunchExpiredObserver {
                 NotificationCenter.default.removeObserver(firstLaunchExpiredObserver)
             }
+            // Re-delivers the attribution payload once, when `isFirstLaunch` expires, so the
+            // listener sees that flip instead of the value captured when the app first launched.
+            // Reads persisted state, no refetch.
             firstLaunchExpiredObserver = NotificationCenter.default.addObserver(
                 forName: .appsOnAirFirstLaunchDidExpire, object: nil, queue: .main
             ) { [weak self] _ in
@@ -144,9 +147,12 @@ import Combine
         /// deep link handling, referral detection, and attribution.
         /// - Parameters:
         ///   - onDeepLinkProcessed: Callback invoked with the resolved deep link and its info.
-        ///   - onAttributionListener: Callback invoked when a referral fetch actually runs (first open,
-        ///     or no referral cached yet) — same trigger as `onReferralLinkDetected`. Payload includes
-        ///     referral info plus `isFirstLaunch`, `firstInstallTime`, `isConsumed`, `attributionStatus`.
+        ///   - onAttributionListener: Fires at most twice — when a referral fetch actually runs
+        ///     (first open, or no referral cached yet), then once more on the return to the
+        ///     foreground that follows `isFirstLaunch` turning `false`, re-delivering the persisted
+        ///     payload without refetching so the listener sees that flip. Later foreground returns
+        ///     are silent. Payload includes referral info plus `isFirstLaunch`, `firstInstallTime`,
+        ///     `isConsumed`, `attributionStatus`.
         @objc
         public func initialize(
             onDeepLinkProcessed: @escaping (URL?, [String: Any]) -> Void,
@@ -161,8 +167,9 @@ import Combine
         /// - Parameters:
         ///   - onDeepLinkProcessed: Callback invoked with the resolved deep link and its info.
         ///   - onReferralLinkDetected: *(Deprecated)* Use `onAttributionListener` instead. Only fires
-        ///     when a referral fetch actually runs (first open, or no referral cached yet). Receives
-        ///     just the raw referral dictionary — use `initialize(onDeepLinkProcessed:onAttributionListener:)`
+        ///     when a referral fetch actually runs (first open, or no referral cached yet) — detection
+        ///     only, so unlike `onAttributionListener` it is not re-delivered on foreground returns.
+        ///     Receives just the raw referral dictionary — use `initialize(onDeepLinkProcessed:onAttributionListener:)`
         ///     for the referral info plus `isFirstLaunch`, `firstInstallTime`, `isConsumed`, `attributionStatus`.
         @available(
             *,
@@ -363,7 +370,9 @@ import Combine
                             var linkInfo = rawLinkInfo
 
                             if (rawLinkInfo[statusCodeKey] as? Int) == successStatusCode {
-                                // isConsumed only takes effect starting the next app launch
+                                // Takes effect immediately: the in-memory value backs
+                                // `isConsumed` in the payload, and the persisted copy carries it
+                                // to later launches.
                                 AppHelper.shared.isConsumed = true
                                 AppHelper.shared.userDefaults.set(true, forKey: isConsumedKey)
 
@@ -493,6 +502,76 @@ import Combine
             self.dispatchGroup.leave()
         }
 
+        /// Reads `attributionTtl`, in seconds, from a referral response — checking the top level
+        /// first and then `data`. Nil when it is absent or not numeric.
+        private func attributionTtl(from linkInfo: [String: Any]?) -> Double? {
+            let data: [String: Any] = linkInfo?[dataKey] as? [String: Any] ?? [:]
+            let rawAttributionTtl =
+                linkInfo?[attributionTtlResponseKey] ?? data[attributionTtlResponseKey]
+
+            switch rawAttributionTtl {
+            case let value as Int: return Double(value)
+            case let value as Double: return value
+            case let value as NSNumber: return value.doubleValue
+            case let value as String: return Double(value)
+            default: return nil
+            }
+        }
+
+        /// True when `attributionTtl` has elapsed since the click, measured against the clock right
+        /// now rather than against the install time. This is a live check, so it is independent of
+        /// `attributionStatus`: an install attributed at first launch still expires once enough
+        /// time passes.
+        ///
+        /// Unknown inputs count as not expired — no clipboard click time, or no `attributionTtl` in
+        /// `storedInfo` — since expiry cannot be demonstrated and the stored referral is the better
+        /// answer. Without the advanced deferred link approach there is no click time at all, so
+        /// this is always false. A device clock that predates the click or the install counts as
+        /// expired: see the comment below.
+        private func isAttributionTtlExpired(_ storedInfo: [String: Any]) -> Bool {
+            guard let clickTimestampInMilliseconds = self.latestClickTimestampInMilliseconds,
+                let attributionTtl = self.attributionTtl(from: storedInfo)
+            else { return false }
+
+            // scale the click time to epoch seconds so both sides use the same unit
+            let clickTimestampInSeconds = Measurement(
+                value: clickTimestampInMilliseconds, unit: UnitDuration.milliseconds
+            ).converted(to: .seconds).value
+
+            // Corrected by the last server Date header, so a device clock that is merely wrong still
+            // measures the window correctly. See `AppHelper.recordServerDate` for what this does
+            // and does not stop.
+            let now = self.appHelper.correctedNow
+
+            // Time only moves forward. Corrected now falling behind something already observed
+            // means the clock was wound back between observations.
+            if self.appHelper.hasClockRewound {
+                Logger.logInternal("Clock moved backwards, treating attribution as expired")
+                return true
+            }
+
+            // The click time is stamped by the link service and the install date by the filesystem,
+            // so neither can be edited from Settings. A now that predates either one is impossible
+            // on an honest clock, and would otherwise shrink the elapsed time and hold the window
+            // open. Treat it as expired so the backend decides, rather than trusting a clock that
+            // has lied.
+            let firstInstallInSeconds = self.appHelper.firstInstallTime.map {
+                Measurement(value: Double($0), unit: UnitDuration.milliseconds)
+                    .converted(to: .seconds).value
+            }
+            if now < clickTimestampInSeconds || (firstInstallInSeconds.map { now < $0 } ?? false) {
+                Logger.logInternal(
+                    "Clock (\(now)) predates click (\(clickTimestampInSeconds)) or install "
+                        + "(\(String(describing: firstInstallInSeconds))), treating attribution as expired"
+                )
+                return true
+            }
+
+            self.appHelper.observeCorrectedTime(now)
+
+            return now - clickTimestampInSeconds > attributionTtl
+        }
+
         private func computeAttributionStatus(
             clickTimestamp: TimeInterval?, linkInfo: [String: Any]?
         ) {
@@ -508,24 +587,9 @@ import Combine
                 return
             }
 
-            // Read TTL from response data when available; default to empty.
-            let data: [String: Any] = linkInfo?[dataKey] as? [String: Any] ?? [:]
-
-            let rawAttributionTtl =
-                linkInfo?[attributionTtlResponseKey] ?? data[attributionTtlResponseKey]
-
-            let attributionTtl: Double?
-            switch rawAttributionTtl {
-            case let value as Int: attributionTtl = Double(value)
-            case let value as Double: attributionTtl = value
-            case let value as NSNumber: attributionTtl = value.doubleValue
-            case let value as String: attributionTtl = Double(value)
-            default: attributionTtl = nil
-            }
-
-            guard let attributionTtl = attributionTtl else {
+            guard let attributionTtl = self.attributionTtl(from: linkInfo) else {
                 Logger.logInternal(
-                    "attributionStatus: no attributionTtl in referral response (raw: \(String(describing: rawAttributionTtl))) — defaulting to non-organic (referral found)"
+                    "attributionStatus: no attributionTtl in referral response — defaulting to non-organic (referral found)"
                 )
                 return
             }
@@ -588,14 +652,9 @@ import Combine
             }
         }
 
-        /// Get referral and attribution info. Same as the deprecated `getReferralInfo`, with attribution info
-        /// nested inside `data`: `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and
-        /// `attributionStatus` — the last resolved status, restored from storage on later launches.
-        @objc public func getAttributionInfo(completion: @escaping ([String: Any]) -> Void) {
-            var attributionInfo =
-                !((self.latestReferralInfo ?? [:]).isEmpty)
-                ? (self.latestReferralInfo ?? [:])
-                : (self.appHelper.readFromKeychain(key: referralData) ?? [:])
+        /// Returns a copy of `info` with the attribution fields added inside `data`.
+        private func withAttribution(_ info: [String: Any]) -> [String: Any] {
+            var attributionInfo = info
 
             // Append attribution fields to response data.
             var data: [String: Any] = attributionInfo[dataKey] as? [String: Any] ?? [:]
@@ -610,7 +669,51 @@ import Combine
             }
             attributionInfo[dataKey] = data
 
-            completion(attributionInfo)
+            return attributionInfo
+        }
+
+        /// Get referral and attribution info. Same as the deprecated `getReferralInfo`, with attribution info
+        /// nested inside `data`: `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and
+        /// `attributionStatus` — the last resolved status, restored from storage on later launches.
+        ///
+        /// Once `attributionTtl` has elapsed since the click, the stored referral no longer
+        /// describes this install, so it is re-read from the IP lookup on every call and that
+        /// response is returned in its place. Inside the window the stored referral is served
+        /// as-is.
+        ///
+        /// `attributionStatus` is deliberately left alone: it stays as it resolved at install time,
+        /// so it and `isConsumed` keep reporting what was attributed even once the payload carries
+        /// the IP based referral. A failed lookup falls back to the stored referral rather than
+        /// surfacing the error object to the host app.
+        @objc public func getAttributionInfo(completion: @escaping ([String: Any]) -> Void) {
+            let storedInfo =
+                !((self.latestReferralInfo ?? [:]).isEmpty)
+                ? (self.latestReferralInfo ?? [:])
+                : (self.appHelper.readFromKeychain(key: referralData) ?? [:])
+
+            guard self.isAttributionTtlExpired(storedInfo) else {
+                completion(self.withAttribution(storedInfo))
+                return
+            }
+
+            AppLinkApiService.apiReferralInfo { rawReferralInfo in
+                // apiReferralInfo completes on a URLSession queue; the callers of this method
+                // (the foreground observer, the RN bridge) all expect main.
+                DispatchQueue.main.async {
+                    guard (rawReferralInfo[statusCodeKey] as? Int) == successStatusCode else {
+                        Logger.logInternal(
+                            "IP referral lookup failed for organic install, falling back to stored referral"
+                        )
+                        completion(self.withAttribution(storedInfo))
+                        return
+                    }
+
+                    var referralInfo = rawReferralInfo
+                    // strip the internal statusCode before exposing it to the host app
+                    referralInfo.removeValue(forKey: statusCodeKey)
+                    completion(self.withAttribution(referralInfo))
+                }
+            }
         }
 
         ///help to handle the get link for referral info

--- a/AppsOnAir_AppLink/AppLinkService.swift
+++ b/AppsOnAir_AppLink/AppLinkService.swift
@@ -163,48 +163,28 @@ import Combine
             referralHandler(isAPICall: true)
         }
 
-        /// Initializes the common services like AppsOnAir Core, swizzling,
-        /// deep link handling, referral detection, and attribution.
-        /// - Parameters:
-        ///   - onDeepLinkProcessed: Callback invoked with the resolved deep link and its info.
-        ///   - onAttributionListener: Fires at most twice — when a referral fetch actually runs
-        ///     (first open, or no referral cached yet), then once more on the return to the
-        ///     foreground that follows `isFirstLaunch` turning `false`, re-delivering the persisted
-        ///     payload without refetching so the listener sees that flip. Later foreground returns
-        ///     are silent. Payload includes referral info plus `isFirstLaunch`, `firstInstallTime`,
-        ///     `isConsumed`, `attributionStatus`.
-        @objc
-        public func initialize(
-            onDeepLinkProcessed: @escaping (URL?, [String: Any]) -> Void,
-            onAttributionListener: (([String: Any]) -> Void)? = nil
-        ) {
-            performInitialization(
-                onDeepLinkProcessed: onDeepLinkProcessed,
-                onAttributionListener: onAttributionListener
-            )
-        }
 
         /// - Parameters:
         ///   - onDeepLinkProcessed: Callback invoked with the resolved deep link and its info.
         ///   - onReferralLinkDetected: *(Deprecated)* Use `onAttributionListener` instead. Only fires
         ///     when a referral fetch actually runs (first open, or no referral cached yet) — detection
         ///     only, so unlike `onAttributionListener` it is not re-delivered on foreground returns.
-        ///     Receives just the raw referral dictionary — use `initialize(onDeepLinkProcessed:onAttributionListener:)`
-        ///     for the referral info plus `isFirstLaunch`, `firstInstallTime`, `isConsumed`, `attributionStatus`.
-        @available(
-            *,
-            deprecated,
-            message:
-                "`onReferralLinkDetected` is deprecated and will be removed in a future release. Use `onAttributionListener` instead."
-        )
-        @objc(initializeOnDeepLinkProcessed:onReferralLinkDetected:)
+        ///     Receives just the raw referral dictionary, with `appsFlyer` removed.
+        ///   - onAttributionListener: Fires at most twice — when a referral fetch actually runs, then
+        ///     once more on the return to the foreground that follows `isFirstLaunch` turning `false`,
+        ///     re-delivering the persisted payload without refetching. Later foreground returns are
+        ///     silent. Payload adds `isFirstLaunch`, `firstInstallTime`, `isConsumed` and
+        ///     `attributionStatus` to the referral info.
+        @objc(initializeOnDeepLinkProcessed:onReferralLinkDetected:onAttributionListener:)
         public func initialize(
             onDeepLinkProcessed: @escaping (URL?, [String: Any]) -> Void,
-            onReferralLinkDetected: (([String: Any]) -> Void)? = nil
+            onReferralLinkDetected: (([String: Any]) -> Void)? = nil,
+            onAttributionListener: (([String: Any]) -> Void)? = nil
         ) {
             performInitialization(
                 onDeepLinkProcessed: onDeepLinkProcessed,
-                onReferralLinkDetected: onReferralLinkDetected
+                onReferralLinkDetected: onReferralLinkDetected,
+                onAttributionListener: onAttributionListener
             )
         }
 

--- a/AppsOnAir_AppLink/AppLinkService.swift
+++ b/AppsOnAir_AppLink/AppLinkService.swift
@@ -43,6 +43,13 @@ import Combine
 
         private var latestReferralInfo: [String: Any]?
 
+        /// The most recent successful post-expiry IP lookup. Held in memory only — like the
+        /// response `resolveReferralInfo` returns, it describes the lookup that ran, not the
+        /// install, so it must not replace the stored referral later launches read.
+        private var refreshedReferralInfo: [String: Any]?
+
+        private var refreshInFlight = false
+
         /// Attribution status: organic/non-organic. Backed by `AppHelper`, which restores it from
         /// UserDefaults on launch and persists every assignment — so a status resolved on first
         /// launch survives relaunches. Defaults to organic until something is resolved and stored.
@@ -725,6 +732,7 @@ import Combine
                     var referralInfo = rawReferralInfo
                     // strip the internal statusCode before exposing it to the host app
                     referralInfo.removeValue(forKey: statusCodeKey)
+                    self.refreshedReferralInfo = referralInfo
                     completion(transform(referralInfo))
                 }
             }
@@ -752,14 +760,51 @@ import Combine
             resolveReferralInfo(storedInfo: storedInfo, transform: withAttribution, completion: completion)
         }
 
-        ///help to handle the get link for referral info
+        /// Serves the freshest referral already held: the last post-expiry lookup when one has
+        /// run, the stored referral otherwise.
+        ///
+        /// This getter completes immediately, so unlike `getReferralInfo` and `getAttributionInfo`
+        /// it does not wait for a lookup. Once `attributionTtl` has elapsed it starts one in the
+        /// background instead, which leaves the first expired call serving the stored referral and
+        /// later calls serving the refreshed one. Android's `getReferralDetails()` is synchronous
+        /// and behaves the same way, so both platforms agree.
         @available(*, deprecated, renamed: "getAttributionInfo")
         @objc public func getReferralDetails(completion: @escaping ([String: Any]) -> Void) {
             // Retrieve stored data from the device keychain
             let referralInfoFromKeyChain = appHelper.readFromKeychain(key: referralData) ?? [:]
-            resolveReferralInfo(
-                storedInfo: referralInfoFromKeyChain, transform: withoutAppsFlyer, completion: completion
-            )
+            let latest = refreshedReferralInfo ?? referralInfoFromKeyChain
+
+            if isAttributionTtlExpired(latest) {
+                refreshReferralInBackground()
+            }
+
+            completion(withoutAppsFlyer(latest))
+        }
+
+        /// Starts a lookup for `getReferralDetails`, which completes without waiting for one. At
+        /// most one runs at a time, so repeated calls past expiry do not pile up requests. A failed
+        /// lookup leaves `refreshedReferralInfo` untouched, so callers keep serving what they had.
+        private func refreshReferralInBackground() {
+            guard !refreshInFlight else { return }
+            refreshInFlight = true
+
+            AppLinkApiService.apiReferralInfo { rawReferralInfo in
+                DispatchQueue.main.async {
+                    self.refreshInFlight = false
+
+                    guard (rawReferralInfo[statusCodeKey] as? Int) == successStatusCode else {
+                        Logger.logInternal(
+                            "Background IP referral lookup failed, keeping the referral already held"
+                        )
+                        return
+                    }
+
+                    var referralInfo = rawReferralInfo
+                    // strip the internal statusCode before exposing it to the host app
+                    referralInfo.removeValue(forKey: statusCodeKey)
+                    self.refreshedReferralInfo = referralInfo
+                }
+            }
         }
 
         ///help to handle the latest link for universal link and custom URL schema

--- a/AppsOnAir_AppLink/AppLinkService.swift
+++ b/AppsOnAir_AppLink/AppLinkService.swift
@@ -388,6 +388,7 @@ import Combine
         ///   - isOpenInAndroidApp: `NSNumber` (e.g., `1` or `0`) indicating whether the link should open directly in the Android app.
         ///   - isOpenInBrowserAndroid: `NSNumber` (e.g., `1` or `0`) indicating whether the link should open in a browser on Android.
         ///   - androidFallbackUrl: *(Optional)* Fallback URL used if the app is not installed on Android.
+        ///   - appsFlyer: *(Optional)* Dictionary containing AppsFlyer attribution params (e.g., channel, campaignId, campaign, subs, metaTitle, metaDescription).
         ///   - completion: A closure that returns a dictionary containing the result of the link creation.
         @objc public func createAppLink(
             url: String,
@@ -401,6 +402,7 @@ import Combine
             isOpenInAndroidApp: NSNumber?,
             isOpenInBrowserAndroid: NSNumber?,
             androidFallbackUrl: String? = nil,
+            appsFlyer: [String: Any]? = nil,
             completion: @escaping ([String: Any]) -> Void
         ) {
             // Convert NSNumber? to Bool? for Swift compatibility
@@ -422,6 +424,7 @@ import Combine
                 isOpenInAndroidApp: isOpenInAndroidAppNumber,
                 isOpenInBrowserAndroid: isOpenInBrowserAndroidNumber,
                 androidFallbackUrl: androidFallbackUrl,
+                appsFlyer: appsFlyer,
                 completion: completion
             )
         }
@@ -438,6 +441,7 @@ import Combine
         ///   - isOpenInAndroidApp: `Bool` indicating whether the link should open directly in the Android app.
         ///   - isOpenInBrowserAndroid: `Bool` indicating whether the link should open in a browser on Android.
         ///   - androidFallbackUrl: *(Optional)* Fallback URL used if the app is not installed on Android.
+        ///   - appsFlyer: *(Optional)* Dictionary containing AppsFlyer attribution params (e.g., channel, campaignId, campaign, subs, metaTitle, metaDescription).
         ///   - completion: A closure that returns a dictionary containing the result of the link creation.
         public func createAppLink(
             url: String,
@@ -451,6 +455,7 @@ import Combine
             isOpenInAndroidApp: Bool? = nil,
             isOpenInBrowserAndroid: Bool? = nil,
             androidFallbackUrl: String? = nil,
+            appsFlyer: [String: Any]? = nil,
             completion: @escaping ([String: Any]) -> Void
         ) {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
@@ -488,7 +493,8 @@ import Combine
                         isOpenInIosApp: isOpenInIosApp, iosFallbackUrl: iosFallbackUrl,
                         isOpenInAndroidApp: isOpenInAndroidApp,
                         isOpenInBrowserAndroid: isOpenInBrowserAndroid,
-                        androidFallbackUrl: androidFallbackUrl
+                        androidFallbackUrl: androidFallbackUrl,
+                        appsFlyer: appsFlyer
                     ) { shortLinkData in
                         completion(shortLinkData)
                     }

--- a/AppsOnAir_AppLink/AppLinkService.swift
+++ b/AppsOnAir_AppLink/AppLinkService.swift
@@ -35,6 +35,9 @@ import Combine
         //Latest link for Referral Link
         @Published var latestReferralURL: URL?
 
+        //Latest payload for Attribution
+        @Published var latestAttributionInfo: [String: Any]?
+
         // Listener for whenever link is Update
         private var linkListener: AnyCancellable?
 
@@ -66,6 +69,9 @@ import Combine
         // Listener for whenever referral link is Update
         private var referralLinkListener: AnyCancellable?
 
+        // Listener for whenever attribution info is Update
+        private var attributionInfoListener: AnyCancellable?
+
         // Manage for API call
         private let dispatchGroup = DispatchGroup()
 
@@ -76,6 +82,7 @@ import Combine
             // Cancel the listener when the object is deallocated
             linkListener?.cancel()
             referralLinkListener?.cancel()
+            attributionInfoListener?.cancel()
             NotificationCenter.default.removeObserver(self)
         }
 
@@ -92,6 +99,19 @@ import Combine
             _ = AppSwizzler.shared
 
             attributionListener = onAttributionListener
+
+            // Attribution listener: fires whenever `latestAttributionInfo` is updated, regardless
+            // of which call site (foreground re-fire or referral-detected flow) produced it.
+            // Subscribing before any assignment happens means dropFirst() only skips the initial
+            // nil emitted on subscribe, not a real payload.
+            attributionInfoListener?.cancel()
+            attributionInfoListener = self.$latestAttributionInfo
+                .dropFirst()
+                .compactMap { $0 }
+                .sink { [weak self] attributionInfo in
+                    self?.attributionListener?(attributionInfo)
+                }
+
             if let firstLaunchExpiredObserver {
                 NotificationCenter.default.removeObserver(firstLaunchExpiredObserver)
             }
@@ -106,7 +126,7 @@ import Combine
                     "AppLinkService: appsOnAirFirstLaunchDidExpire received, re-firing onAttributionListener"
                 )
                 self.getAttributionInfo { attributionInfo in
-                    self.attributionListener?(attributionInfo)
+                    self.latestAttributionInfo = attributionInfo
                 }
             }
 
@@ -132,7 +152,7 @@ import Combine
                                 onReferralLinkDetected?(self.withoutAppsFlyer(referralInfo))
 
                                 self.getAttributionInfo { attributionInfo in
-                                    onAttributionListener?(attributionInfo)
+                                    self.latestAttributionInfo = attributionInfo
                                 }
                             }
                         }
@@ -531,7 +551,7 @@ import Combine
         private func isAttributionTtlExpired(_ storedInfo: [String: Any]) -> Bool {
             guard let clickTimestampInMilliseconds = self.latestClickTimestampInMilliseconds,
                 let attributionTtl = self.attributionTtl(from: storedInfo)
-            else { return false }
+            else { return true }
 
             // scale the click time to epoch seconds so both sides use the same unit
             let clickTimestampInSeconds = Measurement(
@@ -643,12 +663,14 @@ import Combine
         @available(*, deprecated, renamed: "getAttributionInfo")
         @objc public func getReferralInfo(completion: @escaping ([String: Any]) -> Void) {
             dispatchGroup.notify(queue: .main) {
-                if !((self.latestReferralInfo ?? [:]).isEmpty) {
-                    completion(self.withoutAppsFlyer(self.latestReferralInfo ?? [:]))
-                    return
-                }
-                let referralInfoFromKeyChain = self.appHelper.readFromKeychain(key: referralData)
-                completion(self.withoutAppsFlyer(referralInfoFromKeyChain ?? [:]))
+                let storedInfo =
+                    !((self.latestReferralInfo ?? [:]).isEmpty)
+                    ? (self.latestReferralInfo ?? [:])
+                    : (self.appHelper.readFromKeychain(key: referralData) ?? [:])
+
+                self.resolveReferralInfo(
+                    storedInfo: storedInfo, transform: self.withoutAppsFlyer, completion: completion
+                )
             }
         }
 
@@ -672,6 +694,42 @@ import Combine
             return attributionInfo
         }
 
+        /// Resolves referral info for a call site: serves `storedInfo` as-is while
+        /// `attributionTtl` hasn't elapsed, otherwise re-reads it from the IP lookup and serves
+        /// that response in its place. A failed lookup falls back to the raw lookup response
+        /// rather than surfacing an error to the host app. `transform` shapes the final payload —
+        /// `withAttribution` for `getAttributionInfo`, `withoutAppsFlyer` for the deprecated
+        /// referral getters.
+        private func resolveReferralInfo(
+            storedInfo: [String: Any],
+            transform: @escaping ([String: Any]) -> [String: Any],
+            completion: @escaping ([String: Any]) -> Void
+        ) {
+            guard self.isAttributionTtlExpired(storedInfo) else {
+                completion(transform(storedInfo))
+                return
+            }
+
+            AppLinkApiService.apiReferralInfo { rawReferralInfo in
+                // apiReferralInfo completes on a URLSession queue; the callers of this method
+                // (the foreground observer, the RN bridge) all expect main.
+                DispatchQueue.main.async {
+                    guard (rawReferralInfo[statusCodeKey] as? Int) == successStatusCode else {
+                        Logger.logInternal(
+                            "IP referral lookup failed for organic install, falling back to stored referral"
+                        )
+                        completion(transform(rawReferralInfo))
+                        return
+                    }
+
+                    var referralInfo = rawReferralInfo
+                    // strip the internal statusCode before exposing it to the host app
+                    referralInfo.removeValue(forKey: statusCodeKey)
+                    completion(transform(referralInfo))
+                }
+            }
+        }
+
         /// Get referral and attribution info. Same as the deprecated `getReferralInfo`, with attribution info
         /// nested inside `data`: `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and
         /// `attributionStatus` — the last resolved status, restored from storage on later launches.
@@ -691,37 +749,17 @@ import Combine
                 ? (self.latestReferralInfo ?? [:])
                 : (self.appHelper.readFromKeychain(key: referralData) ?? [:])
 
-            guard self.isAttributionTtlExpired(storedInfo) else {
-                completion(self.withAttribution(storedInfo))
-                return
-            }
-
-            AppLinkApiService.apiReferralInfo { rawReferralInfo in
-                // apiReferralInfo completes on a URLSession queue; the callers of this method
-                // (the foreground observer, the RN bridge) all expect main.
-                DispatchQueue.main.async {
-                    guard (rawReferralInfo[statusCodeKey] as? Int) == successStatusCode else {
-                        Logger.logInternal(
-                            "IP referral lookup failed for organic install, falling back to stored referral"
-                        )
-                        completion(self.withAttribution(rawReferralInfo))
-                        return
-                    }
-
-                    var referralInfo = rawReferralInfo
-                    // strip the internal statusCode before exposing it to the host app
-                    referralInfo.removeValue(forKey: statusCodeKey)
-                    completion(self.withAttribution(referralInfo))
-                }
-            }
+            resolveReferralInfo(storedInfo: storedInfo, transform: withAttribution, completion: completion)
         }
 
         ///help to handle the get link for referral info
         @available(*, deprecated, renamed: "getAttributionInfo")
         @objc public func getReferralDetails(completion: @escaping ([String: Any]) -> Void) {
             // Retrieve stored data from the device keychain
-            let referralInfoFromKeyChain = appHelper.readFromKeychain(key: referralData)
-            completion(withoutAppsFlyer(referralInfoFromKeyChain ?? [:]))
+            let referralInfoFromKeyChain = appHelper.readFromKeychain(key: referralData) ?? [:]
+            resolveReferralInfo(
+                storedInfo: referralInfoFromKeyChain, transform: withoutAppsFlyer, completion: completion
+            )
         }
 
         ///help to handle the latest link for universal link and custom URL schema

--- a/AppsOnAir_AppLink/AppLinkService.swift
+++ b/AppsOnAir_AppLink/AppLinkService.swift
@@ -541,22 +541,31 @@ import Combine
         /// True when `attributionTtl` has elapsed since the click, measured against the clock right
         /// now rather than against the install time. This is a live check, so it is independent of
         /// `attributionStatus`: an install attributed at first launch still expires once enough
-        /// time passes.
+        /// time passes, which is how the Android SDK measures the window.
         ///
-        /// Unknown inputs count as not expired — no clipboard click time, or no `attributionTtl` in
-        /// `storedInfo` — since expiry cannot be demonstrated and the stored referral is the better
-        /// answer. Without the advanced deferred link approach there is no click time at all, so
-        /// this is always false. A device clock that predates the click or the install counts as
-        /// expired: see the comment below.
+        /// Unknown inputs count as expired: an `attributionTtl` that is not in `storedInfo`, or
+        /// neither a click time nor an install time to measure the window from. Expiry cannot be
+        /// demonstrated in either case, so the referral is refreshed rather than trusted. A device
+        /// clock that predates the click or the install also counts as expired: see the comment
+        /// below.
         private func isAttributionTtlExpired(_ storedInfo: [String: Any]) -> Bool {
-            guard let clickTimestampInMilliseconds = self.latestClickTimestampInMilliseconds,
-                let attributionTtl = self.attributionTtl(from: storedInfo)
-            else { return true }
+            guard let attributionTtl = self.attributionTtl(from: storedInfo) else { return true }
 
-            // scale the click time to epoch seconds so both sides use the same unit
-            let clickTimestampInSeconds = Measurement(
-                value: clickTimestampInMilliseconds, unit: UnitDuration.milliseconds
-            ).converted(to: .seconds).value
+            // scale every epoch input to seconds so the comparisons below use one unit
+            let clickTimestampInSeconds = self.latestClickTimestampInMilliseconds.map {
+                Measurement(value: $0, unit: UnitDuration.milliseconds)
+                    .converted(to: .seconds).value
+            }
+            let firstInstallInSeconds = self.appHelper.firstInstallTime.map {
+                Measurement(value: Double($0), unit: UnitDuration.milliseconds)
+                    .converted(to: .seconds).value
+            }
+
+            // The window runs from the click. An organic install has none, and neither does a
+            // referral that carried no click time, so the install stands in for it: the stored
+            // referral stops being current once the ttl has passed either way.
+            guard let windowStartInSeconds = clickTimestampInSeconds ?? firstInstallInSeconds
+            else { return true }
 
             // Corrected by the last server Date header, so a device clock that is merely wrong still
             // measures the window correctly. See `AppHelper.recordServerDate` for what this does
@@ -575,48 +584,53 @@ import Combine
             // on an honest clock, and would otherwise shrink the elapsed time and hold the window
             // open. Treat it as expired so the backend decides, rather than trusting a clock that
             // has lied.
-            let firstInstallInSeconds = self.appHelper.firstInstallTime.map {
-                Measurement(value: Double($0), unit: UnitDuration.milliseconds)
-                    .converted(to: .seconds).value
-            }
-            if now < clickTimestampInSeconds || (firstInstallInSeconds.map { now < $0 } ?? false) {
+            if now < windowStartInSeconds || (firstInstallInSeconds.map { now < $0 } ?? false) {
                 Logger.logInternal(
-                    "Clock (\(now)) predates click (\(clickTimestampInSeconds)) or install "
-                        + "(\(String(describing: firstInstallInSeconds))), treating attribution as expired"
+                    "Clock (\(now)) predates click (\(String(describing: clickTimestampInSeconds))) "
+                        + "or install (\(String(describing: firstInstallInSeconds))), "
+                        + "treating attribution as expired"
                 )
                 return true
             }
 
             self.appHelper.observeCorrectedTime(now)
 
-            return now - clickTimestampInSeconds > attributionTtl
+            let elapsedInSeconds = now - windowStartInSeconds
+
+            Logger.logInternal(
+                "attributionTtl: now - windowStart = \(elapsedInSeconds)s, ttl: \(attributionTtl)s"
+            )
+
+            return elapsedInSeconds > attributionTtl
         }
 
         private func computeAttributionStatus(
             clickTimestamp: TimeInterval?, linkInfo: [String: Any]?
         ) {
-            // Referral found; default to non-organic and refine with click-time data.
-            latestAttributionStatus = attributionStatusNonOrganic
+            // An install is non-organic when it happened within `attributionTtl` of the click. Any
+            // missing input falls back to organic, matching the Android SDK: without all three
+            // there is nothing to show the click is what brought this install.
+            latestAttributionStatus = attributionStatusOrganic
 
             // Clipboard `applink_click_time` is in milliseconds. Already retained where it was read
             // from the clipboard, so it is only consumed here.
             guard let clickTimestampInMilliseconds = clickTimestamp else {
                 Logger.logInternal(
-                    "attributionStatus: no applink_click_time in clipboard — defaulting to non-organic (referral found)"
+                    "attributionStatus: no applink_click_time in clipboard — defaulting to organic"
                 )
                 return
             }
 
             guard let attributionTtl = self.attributionTtl(from: linkInfo) else {
                 Logger.logInternal(
-                    "attributionStatus: no attributionTtl in referral response — defaulting to non-organic (referral found)"
+                    "attributionStatus: no attributionTtl in referral response — defaulting to organic"
                 )
                 return
             }
 
             guard let firstInstallMilliseconds = appHelper.firstInstallTime else {
                 Logger.logInternal(
-                    "attributionStatus: could not read firstInstallTime — defaulting to non-organic (referral found)"
+                    "attributionStatus: could not read firstInstallTime — defaulting to organic"
                 )
                 return
             }
@@ -694,12 +708,15 @@ import Combine
             return attributionInfo
         }
 
-        /// Resolves referral info for a call site: serves `storedInfo` as-is while
-        /// `attributionTtl` hasn't elapsed, otherwise re-reads it from the IP lookup and serves
-        /// that response in its place. A failed lookup falls back to the raw lookup response
-        /// rather than surfacing an error to the host app. `transform` shapes the final payload —
-        /// `withAttribution` for `getAttributionInfo`, `withoutAppsFlyer` for the deprecated
-        /// referral getters.
+        /// Resolves referral info for a call site: serves `storedInfo` as-is while the click still
+        /// falls inside `attributionTtl`, otherwise re-reads it from the IP lookup and serves that
+        /// response in its place. The window is measured against the clock at call time, so a call
+        /// made once enough time has passed takes the lookup branch even though an earlier call on
+        /// the same install did not. Once the window has lapsed the lookup response is what is
+        /// returned, error payloads included: the stored referral no longer describes this install,
+        /// so it is not served in place of what the backend answered.
+        /// `transform` shapes the final payload — `withAttribution` for `getAttributionInfo`,
+        /// `withoutAppsFlyer` for the deprecated referral getters.
         private func resolveReferralInfo(
             storedInfo: [String: Any],
             transform: @escaping ([String: Any]) -> [String: Any],
@@ -715,8 +732,11 @@ import Combine
                 // (the foreground observer, the RN bridge) all expect main.
                 DispatchQueue.main.async {
                     guard (rawReferralInfo[statusCodeKey] as? Int) == successStatusCode else {
+                        // The lookup is the answer once the window has lapsed, so its error
+                        // payload goes to the host app as it came back — `statusCode` included —
+                        // instead of being replaced by a stored referral that has expired.
                         Logger.logInternal(
-                            "IP referral lookup failed for organic install, falling back to stored referral"
+                            "IP referral lookup failed, returning the lookup response"
                         )
                         completion(transform(rawReferralInfo))
                         return
@@ -735,14 +755,15 @@ import Combine
         /// `attributionStatus` — the last resolved status, restored from storage on later launches.
         ///
         /// Once `attributionTtl` has elapsed since the click, the stored referral no longer
-        /// describes this install, so it is re-read from the IP lookup on every call and that
-        /// response is returned in its place. Inside the window the stored referral is served
-        /// as-is.
+        /// describes this install, so it is re-read from the IP lookup and that response is
+        /// returned in its place. Inside the window the stored referral is served as-is. The
+        /// elapsed time is measured against the clock at call time, matching the Android SDK, so
+        /// the window does lapse while the app is in use.
         ///
         /// `attributionStatus` is deliberately left alone: it stays as it resolved at install time,
         /// so it and `isConsumed` keep reporting what was attributed even once the payload carries
-        /// the IP based referral. A failed lookup falls back to the stored referral rather than
-        /// surfacing the error object to the host app.
+        /// the IP based referral. A failed lookup surfaces the lookup response itself, so an
+        /// expired referral is never served as if it were current.
         @objc public func getAttributionInfo(completion: @escaping ([String: Any]) -> Void) {
             let storedInfo =
                 !((self.latestReferralInfo ?? [:]).isEmpty)

--- a/AppsOnAir_AppLink/AppLinkService.swift
+++ b/AppsOnAir_AppLink/AppLinkService.swift
@@ -20,7 +20,7 @@ import Combine
         }
 
         /// Device's first install time, as an epoch String
-        internal var firstInstallTime: String? {
+        internal var firstInstallTime: Int64? {
             return appHelper.firstInstallTime
         }
 
@@ -40,9 +40,28 @@ import Combine
 
         private var latestReferralInfo: [String: Any]?
 
-        // Attribution status: organic/non-organic; defaults to organic until resolved.
+        /// Attribution status: organic/non-organic. Backed by `AppHelper`, which restores it from
+        /// UserDefaults on launch and persists every assignment — so a status resolved on first
+        /// launch survives relaunches. Defaults to organic until something is resolved and stored.
+        private var latestAttributionStatus: String {
+            get { appHelper.attributionStatus }
+            set { appHelper.updateAttributionStatus(newValue) }
+        }
 
-        private var latestAttributionStatus: String? = attributionStatusOrganic
+        /// Clipboard `applink_click_time` in epoch milliseconds, retained so `getAttributionInfo`
+        /// can report it alongside the Android SDK's equivalent field. Nil until a deferred link
+        /// carrying the param is resolved.
+        /// Backed by `AppHelper`, which restores it from UserDefaults on launch and persists every
+        /// assignment. The clipboard is only read on first open, so without persistence this would
+        /// be nil from launch 2 onward and drop out of the attribution payload.
+        /// Assigning nil is ignored — a later launch with no clipboard must not erase it.
+        private var latestClickTimestampInMilliseconds: TimeInterval? {
+            get { appHelper.clickTime }
+            set {
+                guard let newValue else { return }
+                appHelper.updateClickTime(newValue)
+            }
+        }
 
         // Listener for whenever referral link is Update
         private var referralLinkListener: AnyCancellable?
@@ -107,7 +126,7 @@ import Combine
 
                         self.referralHandler(isCompletionCall: true) { referralInfo in
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) {
-                                onReferralLinkDetected?(referralInfo)
+                                onReferralLinkDetected?(self.withoutAppsFlyer(referralInfo))
 
                                 self.getAttributionInfo { attributionInfo in
                                     onAttributionListener?(attributionInfo)
@@ -331,6 +350,10 @@ import Combine
                             .first(where: { $0.name == applinkClickTimeParam })?.value
                             .flatMap { Double($0) }
 
+                        // Retain it as soon as it is read, so it reaches the attribution payload
+                        // even when the referral call fails or the status is never computed.
+                        self.latestClickTimestampInMilliseconds = clickTimestamp
+
                         AppLinkApiService.apiReferralInfo(
                             appLinParams: appLinkReferralLinkParams,
                             isEnableAdvancedDeferredLink: true
@@ -354,17 +377,12 @@ import Combine
                             self.latestReferralURL = url
 
                             if referralStatus == "SUCCESS" {
-                                // clipboard-only: compare click time vs first install time vs attributionTtl
+                                // clipboard-only: compare click time vs first install time vs attributionTtl.
+                                // The resolved status is persisted by `computeAttributionStatus` itself and
+                                // read back in `getAttributionInfo`, so it is not copied into `linkInfo` here.
                                 self.computeAttributionStatus(
                                     clickTimestamp: clickTimestamp,
                                     linkInfo: linkInfo)
-
-                                // persist attributionStatus alongside the referral data
-                                if let attributionStatus = self.latestAttributionStatus {
-                                    var data = linkInfo[dataKey] as? [String: Any] ?? [:]
-                                    data[attributionStatusKey] = attributionStatus
-                                    linkInfo[dataKey] = data
-                                }
                             }
 
                             if referralStatus == "SUCCESS" {
@@ -481,7 +499,8 @@ import Combine
             // Referral found; default to non-organic and refine with click-time data.
             latestAttributionStatus = attributionStatusNonOrganic
 
-            // Clipboard `applink_click_time` is in milliseconds.
+            // Clipboard `applink_click_time` is in milliseconds. Already retained where it was read
+            // from the clipboard, so it is only consumed here.
             guard let clickTimestampInMilliseconds = clickTimestamp else {
                 Logger.logInternal(
                     "attributionStatus: no applink_click_time in clipboard — defaulting to non-organic (referral found)"
@@ -511,12 +530,17 @@ import Combine
                 return
             }
 
-            guard let firstInstallEpoch = Double(appHelper.firstInstallTime ?? "") else {
+            guard let firstInstallMilliseconds = appHelper.firstInstallTime else {
                 Logger.logInternal(
                     "attributionStatus: could not read firstInstallTime — defaulting to non-organic (referral found)"
                 )
                 return
             }
+
+            // firstInstallTime is epoch milliseconds; the comparison below works in seconds.
+            let firstInstallEpoch = Measurement(
+                value: Double(firstInstallMilliseconds), unit: UnitDuration.milliseconds
+            ).converted(to: .seconds).value
 
             // scale the click time to epoch seconds so both sides use the same unit
             let clickTimestampInSeconds: Double
@@ -532,8 +556,23 @@ import Combine
                 ? attributionStatusOrganic : attributionStatusNonOrganic
 
             Logger.logInternal(
-                "attributionStatus = \(latestAttributionStatus ?? "nil") (diff: \(diffInSeconds)s, ttl: \(attributionTtl)s)"
+                "attributionStatus = \(latestAttributionStatus) (diff: \(diffInSeconds)s, ttl: \(attributionTtl)s)"
             )
+        }
+
+        /// Returns a copy of `info` without the `appsFlyer` object. The API returns it on the
+        /// dynamic-link and referral/details endpoints, but it belongs to the newer attribution
+        /// surface: only `getAttributionInfo` / `onAttributionListener` expose it, so the
+        /// deprecated referral APIs and `onReferralLinkDetected` keep their original payload.
+        /// Removed at both levels because the key may sit at the root or inside `data`.
+        private func withoutAppsFlyer(_ info: [String: Any]) -> [String: Any] {
+            var info = info
+            info.removeValue(forKey: appsFlyerKey)
+            if var data = info[dataKey] as? [String: Any] {
+                data.removeValue(forKey: appsFlyerKey)
+                info[dataKey] = data
+            }
+            return info
         }
 
         /// (Deprecated) Get referral info
@@ -541,17 +580,17 @@ import Combine
         @objc public func getReferralInfo(completion: @escaping ([String: Any]) -> Void) {
             dispatchGroup.notify(queue: .main) {
                 if !((self.latestReferralInfo ?? [:]).isEmpty) {
-                    completion(self.latestReferralInfo ?? [:])
+                    completion(self.withoutAppsFlyer(self.latestReferralInfo ?? [:]))
                     return
                 }
                 let referralInfoFromKeyChain = self.appHelper.readFromKeychain(key: referralData)
-                completion(referralInfoFromKeyChain ?? [:])
+                completion(self.withoutAppsFlyer(referralInfoFromKeyChain ?? [:]))
             }
         }
 
         /// Get referral and attribution info. Same as the deprecated `getReferralInfo`, with attribution info
-        /// nested inside `data`: `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and (clipboard
-        /// approach only) `attributionStatus`.
+        /// nested inside `data`: `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and
+        /// `attributionStatus` — the last resolved status, restored from storage on later launches.
         @objc public func getAttributionInfo(completion: @escaping ([String: Any]) -> Void) {
             var attributionInfo =
                 !((self.latestReferralInfo ?? [:]).isEmpty)
@@ -565,8 +604,9 @@ import Combine
                 data[firstInstallTimeKey] = firstInstallTime
             }
             data[isConsumedKey] = self.isConsumed
-            if let attributionStatus = self.latestAttributionStatus {
-                data[attributionStatusKey] = attributionStatus
+            data[attributionStatusKey] = self.latestAttributionStatus
+            if let clickTimestamp = self.latestClickTimestampInMilliseconds {
+                data[applinkClickTimeParam] = Int64(clickTimestamp.rounded())
             }
             attributionInfo[dataKey] = data
 
@@ -578,7 +618,7 @@ import Combine
         @objc public func getReferralDetails(completion: @escaping ([String: Any]) -> Void) {
             // Retrieve stored data from the device keychain
             let referralInfoFromKeyChain = appHelper.readFromKeychain(key: referralData)
-            completion(referralInfoFromKeyChain ?? [:])
+            completion(withoutAppsFlyer(referralInfoFromKeyChain ?? [:]))
         }
 
         ///help to handle the latest link for universal link and custom URL schema

--- a/AppsOnAir_AppLink/AppLinkService.swift
+++ b/AppsOnAir_AppLink/AppLinkService.swift
@@ -43,13 +43,6 @@ import Combine
 
         private var latestReferralInfo: [String: Any]?
 
-        /// The most recent successful post-expiry IP lookup. Held in memory only — like the
-        /// response `resolveReferralInfo` returns, it describes the lookup that ran, not the
-        /// install, so it must not replace the stored referral later launches read.
-        private var refreshedReferralInfo: [String: Any]?
-
-        private var refreshInFlight = false
-
         /// Attribution status: organic/non-organic. Backed by `AppHelper`, which restores it from
         /// UserDefaults on launch and persists every assignment — so a status resolved on first
         /// launch survives relaunches. Defaults to organic until something is resolved and stored.
@@ -732,7 +725,6 @@ import Combine
                     var referralInfo = rawReferralInfo
                     // strip the internal statusCode before exposing it to the host app
                     referralInfo.removeValue(forKey: statusCodeKey)
-                    self.refreshedReferralInfo = referralInfo
                     completion(transform(referralInfo))
                 }
             }
@@ -760,51 +752,14 @@ import Combine
             resolveReferralInfo(storedInfo: storedInfo, transform: withAttribution, completion: completion)
         }
 
-        /// Serves the freshest referral already held: the last post-expiry lookup when one has
-        /// run, the stored referral otherwise.
-        ///
-        /// This getter completes immediately, so unlike `getReferralInfo` and `getAttributionInfo`
-        /// it does not wait for a lookup. Once `attributionTtl` has elapsed it starts one in the
-        /// background instead, which leaves the first expired call serving the stored referral and
-        /// later calls serving the refreshed one. Android's `getReferralDetails()` is synchronous
-        /// and behaves the same way, so both platforms agree.
+        ///help to handle the get link for referral info
         @available(*, deprecated, renamed: "getAttributionInfo")
         @objc public func getReferralDetails(completion: @escaping ([String: Any]) -> Void) {
             // Retrieve stored data from the device keychain
             let referralInfoFromKeyChain = appHelper.readFromKeychain(key: referralData) ?? [:]
-            let latest = refreshedReferralInfo ?? referralInfoFromKeyChain
-
-            if isAttributionTtlExpired(latest) {
-                refreshReferralInBackground()
-            }
-
-            completion(withoutAppsFlyer(latest))
-        }
-
-        /// Starts a lookup for `getReferralDetails`, which completes without waiting for one. At
-        /// most one runs at a time, so repeated calls past expiry do not pile up requests. A failed
-        /// lookup leaves `refreshedReferralInfo` untouched, so callers keep serving what they had.
-        private func refreshReferralInBackground() {
-            guard !refreshInFlight else { return }
-            refreshInFlight = true
-
-            AppLinkApiService.apiReferralInfo { rawReferralInfo in
-                DispatchQueue.main.async {
-                    self.refreshInFlight = false
-
-                    guard (rawReferralInfo[statusCodeKey] as? Int) == successStatusCode else {
-                        Logger.logInternal(
-                            "Background IP referral lookup failed, keeping the referral already held"
-                        )
-                        return
-                    }
-
-                    var referralInfo = rawReferralInfo
-                    // strip the internal statusCode before exposing it to the host app
-                    referralInfo.removeValue(forKey: statusCodeKey)
-                    self.refreshedReferralInfo = referralInfo
-                }
-            }
+            resolveReferralInfo(
+                storedInfo: referralInfoFromKeyChain, transform: withoutAppsFlyer, completion: completion
+            )
         }
 
         ///help to handle the latest link for universal link and custom URL schema

--- a/AppsOnAir_AppLink/AppLinkService.swift
+++ b/AppsOnAir_AppLink/AppLinkService.swift
@@ -14,6 +14,21 @@ import Combine
         //App Helper service initialization
         let appHelper = AppHelper.shared
 
+        /// `true` only on the very first app launch
+        internal var isFirstLaunch: Bool {
+            return appHelper.isAppFirstOpen
+        }
+
+        /// Device's first install time
+        internal var firstInstallTime: String {
+            return appHelper.firstInstallTime
+        }
+
+        /// `false` this session until a successful referral fetch
+        internal var isConsumed: Bool {
+            return appHelper.isConsumed
+        }
+
         //Latest link for Dynamic Link
         @Published var latestLink: URL?
 
@@ -24,6 +39,12 @@ import Combine
         private var linkListener: AnyCancellable?
 
         private var latestReferralInfo: [String: Any]?
+
+        // "organic" / "nonorganic", computed only for the clipboard (advanced deferred link) approach.
+        // Defaults to organic (no referral found yet / error). Once a referral is found via the API
+        // without error, it becomes nonorganic — refined to organic/nonorganic by the click-time vs
+        // attributionTtl diff when that data is available.
+        private var latestAttributionStatus: String? = attributionStatusOrganic
 
         // Listener for whenever referral link is Update
         private var referralLinkListener: AnyCancellable?
@@ -37,42 +58,90 @@ import Combine
             referralLinkListener?.cancel()
         }
 
-        //initialize the common services like AppsOnAir-Core and swizzling method and fetch the latest Link
-        ///fetch the latest link for universal link and custom URL schema
-        ///fetch the latest link for referral link and
-        @objc public func initialize(
+        /// Common initialization flow
+        private func performInitialization(
             onDeepLinkProcessed: @escaping (URL?, [String: Any]) -> Void,
-            onReferralLinkDetected: (([String: Any]) -> Void)? = nil
+            onReferralLinkDetected: (([String: Any]) -> Void)? = nil,
+            onAttributionListener: (([String: Any]) -> Void)? = nil
         ) {
-
-            //initialize the AppsOnAir-core
+            // Initialize AppsOnAir Core
             appsOnAirCoreServices.initialize()
 
             // Initialize swizzling
             _ = AppSwizzler.shared
 
-            // handle the internet connectivity abd listen for network status changes
+            // Listen for network status
             appsOnAirCoreServices.networkStatusListenerHandler { isConnected in
                 guard self.linkListener == nil else { return }
-                // Listener for link and link info
+
+                // Deep link listener
                 self.linkListener = self.$latestLink.sink { [weak self] _ in
                     self?.onAppLinkHandler(isNetworkConnected: isConnected) { url, linkInfo in
                         onDeepLinkProcessed(url, linkInfo)
                     }
                 }
+
+                // Referral listener
                 self.referralLinkListener = self.$latestReferralURL
                     .dropFirst()
-                    .sink { _ in
-                        self.referralHandler(isCompletionCall: true) { referralInfoFromKeyChain in
+                    .sink { [weak self] _ in
+                        guard let self else { return }
+
+                        self.referralHandler(isCompletionCall: true) { referralInfo in
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) {
-                                onReferralLinkDetected?(referralInfoFromKeyChain)
+                                onReferralLinkDetected?(referralInfo)
+
+                                self.getAttributionInfo { attributionInfo in
+                                    onAttributionListener?(attributionInfo)
+                                }
                             }
                         }
                     }
             }
 
-            // help to referral handling
+            // Trigger referral flow
             referralHandler(isAPICall: true)
+        }
+
+        /// Initializes the common services like AppsOnAir Core, swizzling,
+        /// deep link handling, referral detection, and attribution.
+        /// - Parameters:
+        ///   - onDeepLinkProcessed: Callback invoked with the resolved deep link and its info.
+        ///   - onAttributionListener: Callback invoked when a referral fetch actually runs (first open,
+        ///     or no referral cached yet) — same trigger as `onReferralLinkDetected`. Payload includes
+        ///     referral info plus `isFirstLaunch`, `firstInstallTime`, `isConsumed`, `attributionStatus`.
+        @objc
+        public func initialize(
+            onDeepLinkProcessed: @escaping (URL?, [String: Any]) -> Void,
+            onAttributionListener: (([String: Any]) -> Void)? = nil
+        ) {
+            performInitialization(
+                onDeepLinkProcessed: onDeepLinkProcessed,
+                onAttributionListener: onAttributionListener
+            )
+        }
+
+        /// - Parameters:
+        ///   - onDeepLinkProcessed: Callback invoked with the resolved deep link and its info.
+        ///   - onReferralLinkDetected: *(Deprecated)* Use `onAttributionListener` instead. Only fires
+        ///     when a referral fetch actually runs (first open, or no referral cached yet). Receives
+        ///     just the raw referral dictionary — use `initialize(onDeepLinkProcessed:onAttributionListener:)`
+        ///     for the referral info plus `isFirstLaunch`, `firstInstallTime`, `isConsumed`, `attributionStatus`.
+        @available(
+            *,
+            deprecated,
+            message:
+                "`onReferralLinkDetected` is deprecated and will be removed in a future release. Use `onAttributionListener` instead."
+        )
+        @objc(initializeOnDeepLinkProcessed:onReferralLinkDetected:)
+        public func initialize(
+            onDeepLinkProcessed: @escaping (URL?, [String: Any]) -> Void,
+            onReferralLinkDetected: (([String: Any]) -> Void)? = nil
+        ) {
+            performInitialization(
+                onDeepLinkProcessed: onDeepLinkProcessed,
+                onReferralLinkDetected: onReferralLinkDetected
+            )
         }
 
         ///handling when appLink is listen
@@ -193,8 +262,8 @@ import Combine
 
         func isValidShortId(_ linkId: String) -> Bool {
             guard !linkId.isEmpty,
-                  (linkId.split(separator: "/")
-                    .last != nil)
+                linkId.split(separator: "/")
+                    .last != nil
             else {
                 Logger.logInternal(errorShortIdMissing)
                 return false
@@ -228,33 +297,58 @@ import Combine
                             self.dispatchGroup.leave()
                             return
                         }
+                        let clipboardURLComponents = URLComponents(
+                            url: url, resolvingAgainstBaseURL: false)
+
                         var appLinkReferralLinkParams: [String: Any] = [:]
-                        if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-                            let hashKey = components.queryItems?.first(where: {
-                                $0.name == "hash_key"
-                            }
-                            )?.value
-                        {
+                        if let hashKey = clipboardURLComponents?.queryItems?.first(where: {
+                            $0.name == "hash_key"
+                        })?.value {
                             Logger.logInternal("Hash Key: \(hashKey)")
                             appLinkReferralLinkParams["data"] = ["hashKey": hashKey]
                         }
 
+                        // fetch the click time from the clipboard, same as the hash key above
+                        let clickTimestamp: TimeInterval? = clipboardURLComponents?.queryItems?
+                            .first(where: { $0.name == applinkClickTimeParam })?.value
+                            .flatMap { Double($0) }
+
                         AppLinkApiService.apiReferralInfo(
                             appLinParams: appLinkReferralLinkParams,
                             isEnableAdvancedDeferredLink: true
-                        ) { linkInfo in
+                        ) { rawLinkInfo in
                             let _ = self.appHelper.removeDataFromKeychain(key: referralData)
 
-                            self.latestReferralInfo = linkInfo
+                            // isConsumed only takes effect starting the next app launch
+                            if (rawLinkInfo[statusCodeKey] as? Int) == 200 {
+                                AppHelper.shared.isConsumed = true
+                                AppHelper.shared.userDefaults.set(true, forKey: isConsumedKey)
+                            }
 
+                            // strip the internal statusCode before storing/exposing to the host app
+                            var linkInfo = rawLinkInfo
+                            linkInfo.removeValue(forKey: statusCodeKey)
+
+                            let referralStatus = linkInfo["status"] as? String
+                            if referralStatus == "SUCCESS" {
+                                // clipboard-only: compare click time vs first install time vs attributionTtl
+                                self.computeAttributionStatus(
+                                    clickTimestamp: clickTimestamp,
+                                    linkInfo: linkInfo)
+
+                                // persist attributionStatus alongside the referral data
+                                if let attributionStatus = self.latestAttributionStatus {
+                                    var data = linkInfo[dataKey] as? [String: Any] ?? [:]
+                                    data[attributionStatusKey] = attributionStatus
+                                    linkInfo[dataKey] = data
+                                }
+                            }
+
+                            self.latestReferralInfo = linkInfo
                             self.appHelper.saveToKeychain(key: referralData, value: linkInfo)
-
-                            self.latestReferralInfo = linkInfo
                             self.latestReferralURL = url
 
-                            if let referralStatus = linkInfo["status"] as? String,
-                                referralStatus == "SUCCESS"
-                            {
+                            if referralStatus == "SUCCESS" {
                                 AppLinkApiService.apiLinkAnalytics(
                                     isClicked: false,
                                     urlPrefix: domain,
@@ -284,8 +378,18 @@ import Combine
                         }
                     } else {
                         Logger.logInternal("API called")
-                        AppLinkApiService.apiReferralInfo { referralLinkInfo in
+                        AppLinkApiService.apiReferralInfo { rawReferralLinkInfo in
                             let _ = self.appHelper.removeDataFromKeychain(key: referralData)
+
+                            // isConsumed only takes effect starting the next app launch
+                            if (rawReferralLinkInfo[statusCodeKey] as? Int) == 200 {
+                                AppHelper.shared.isConsumed = true
+                                AppHelper.shared.userDefaults.set(true, forKey: isConsumedKey)
+                            }
+
+                            // strip the internal statusCode before storing/exposing to the host app
+                            var referralLinkInfo = rawReferralLinkInfo
+                            referralLinkInfo.removeValue(forKey: statusCodeKey)
 
                             self.latestReferralInfo = referralLinkInfo
 
@@ -351,6 +455,72 @@ import Combine
             self.dispatchGroup.leave()
         }
 
+        private func computeAttributionStatus(
+            clickTimestamp: TimeInterval?, linkInfo: [String: Any]?
+        ) {
+            // Referral was found via the API without error to get here — default to nonorganic,
+            // then refine to organic/nonorganic below if we have enough data to diff click time vs
+            // attributionTtl. (If the referral isn't found at all, this function never runs, and
+            // latestAttributionStatus keeps its class-level default: organic.)
+            latestAttributionStatus = attributionStatusNonOrganic
+
+            guard let clickTimestamp = clickTimestamp else {
+                Logger.logInternal(
+                    "attributionStatus: no applink_click_time in clipboard — defaulting to nonorganic (referral found)"
+                )
+                return
+            }
+
+            let data = linkInfo?["data"] as? [String: Any]
+            let rawAttributionTtl =
+                linkInfo?[attributionTtlResponseKey] ?? data?[attributionTtlResponseKey]
+
+            let attributionTtl: Double?
+            switch rawAttributionTtl {
+            case let value as Int: attributionTtl = Double(value)
+            case let value as Double: attributionTtl = value
+            case let value as NSNumber: attributionTtl = value.doubleValue
+            case let value as String: attributionTtl = Double(value)
+            default: attributionTtl = nil
+            }
+
+            guard let attributionTtl = attributionTtl else {
+                Logger.logInternal(
+                    "attributionStatus: no attributionTtl in referral response (raw: \(String(describing: rawAttributionTtl))) — defaulting to nonorganic (referral found)"
+                )
+                return
+            }
+
+            let installDateFormatter = DateFormatter()
+            installDateFormatter.timeZone = TimeZone.current
+            installDateFormatter.locale = Locale(identifier: "en_US_POSIX")
+            installDateFormatter.dateFormat = "dd-MMM-yyyy hh:mm:ss a"
+
+            guard
+                let installDate = installDateFormatter.date(
+                    from: appHelper.getAppInstallationDate())
+            else {
+                Logger.logInternal(
+                    "attributionStatus: could not parse firstInstallTime — defaulting to nonorganic (referral found)"
+                )
+                return
+            }
+
+            // convert firstInstallTime into epoch time to match clickTimestamp's units
+            let firstInstallEpoch = installDate.timeIntervalSince1970
+            let diffInSeconds = abs(clickTimestamp - firstInstallEpoch)
+
+            latestAttributionStatus =
+                diffInSeconds > attributionTtl
+                ? attributionStatusOrganic : attributionStatusNonOrganic
+
+            Logger.logInternal(
+                "attributionStatus = \(latestAttributionStatus ?? "nil") (diff: \(diffInSeconds)s, ttl: \(attributionTtl)s)"
+            )
+        }
+
+        /// (Deprecated) Get referral info
+        @available(*, deprecated, renamed: "getAttributionInfo")
         @objc public func getReferralInfo(completion: @escaping ([String: Any]) -> Void) {
             dispatchGroup.notify(queue: .main) {
                 if !((self.latestReferralInfo ?? [:]).isEmpty) {
@@ -362,8 +532,29 @@ import Combine
             }
         }
 
+        /// Get referral and attribution info. Same as the deprecated `getReferralInfo`, with attribution info
+        /// nested inside `data`: `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and (clipboard
+        /// approach only) `attributionStatus`.
+        @objc public func getAttributionInfo(completion: @escaping ([String: Any]) -> Void) {
+            var attributionInfo =
+                !((self.latestReferralInfo ?? [:]).isEmpty)
+                ? (self.latestReferralInfo ?? [:])
+                : (self.appHelper.readFromKeychain(key: referralData) ?? [:])
+
+            var data = attributionInfo[dataKey] as? [String: Any] ?? [:]
+            data[isFirstLaunchKey] = self.isFirstLaunch
+            data[firstInstallTimeKey] = self.firstInstallTime
+            data[isConsumedKey] = self.isConsumed
+            if let attributionStatus = self.latestAttributionStatus {
+                data[attributionStatusKey] = attributionStatus
+            }
+            attributionInfo[dataKey] = data
+
+            completion(attributionInfo)
+        }
+
         ///help to handle the get link for referral info
-        @available(*, deprecated, renamed: "getReferralInfo")
+        @available(*, deprecated, renamed: "getAttributionInfo")
         @objc public func getReferralDetails(completion: @escaping ([String: Any]) -> Void) {
             // Retrieve stored data from the device keychain
             let referralInfoFromKeyChain = appHelper.readFromKeychain(key: referralData)
@@ -389,6 +580,7 @@ import Combine
         ///   - isOpenInBrowserAndroid: `NSNumber` (e.g., `1` or `0`) indicating whether the link should open in a browser on Android.
         ///   - androidFallbackUrl: *(Optional)* Fallback URL used if the app is not installed on Android.
         ///   - appsFlyer: *(Optional)* Dictionary containing AppsFlyer attribution params (e.g., channel, campaignId, campaign, subs, metaTitle, metaDescription).
+        ///   - attributionTtl: *(Optional)* `NSNumber` — time-to-live, in seconds, for attribution of this link.
         ///   - completion: A closure that returns a dictionary containing the result of the link creation.
         @objc public func createAppLink(
             url: String,
@@ -403,6 +595,7 @@ import Combine
             isOpenInBrowserAndroid: NSNumber?,
             androidFallbackUrl: String? = nil,
             appsFlyer: [String: Any]? = nil,
+            attributionTtl: NSNumber? = nil,
             completion: @escaping ([String: Any]) -> Void
         ) {
             // Convert NSNumber? to Bool? for Swift compatibility
@@ -410,6 +603,7 @@ import Combine
             let isOpenInIosAppNumber: Bool? = isOpenInIosApp?.boolValue
             let isOpenInAndroidAppNumber: Bool? = isOpenInAndroidApp?.boolValue
             let isOpenInBrowserAndroidNumber: Bool? = isOpenInBrowserAndroid?.boolValue
+            let attributionTtlNumber: Int? = attributionTtl?.intValue
 
             // Call the Swift-native function
             self.createAppLink(
@@ -425,6 +619,7 @@ import Combine
                 isOpenInBrowserAndroid: isOpenInBrowserAndroidNumber,
                 androidFallbackUrl: androidFallbackUrl,
                 appsFlyer: appsFlyer,
+                attributionTtl: attributionTtlNumber,
                 completion: completion
             )
         }
@@ -442,6 +637,7 @@ import Combine
         ///   - isOpenInBrowserAndroid: `Bool` indicating whether the link should open in a browser on Android.
         ///   - androidFallbackUrl: *(Optional)* Fallback URL used if the app is not installed on Android.
         ///   - appsFlyer: *(Optional)* Dictionary containing AppsFlyer attribution params (e.g., channel, campaignId, campaign, subs, metaTitle, metaDescription).
+        ///   - attributionTtl: *(Optional)* Time-to-live, in seconds, for attribution of this link.
         ///   - completion: A closure that returns a dictionary containing the result of the link creation.
         public func createAppLink(
             url: String,
@@ -456,6 +652,7 @@ import Combine
             isOpenInBrowserAndroid: Bool? = nil,
             androidFallbackUrl: String? = nil,
             appsFlyer: [String: Any]? = nil,
+            attributionTtl: Int? = nil,
             completion: @escaping ([String: Any]) -> Void
         ) {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
@@ -494,7 +691,8 @@ import Combine
                         isOpenInAndroidApp: isOpenInAndroidApp,
                         isOpenInBrowserAndroid: isOpenInBrowserAndroid,
                         androidFallbackUrl: androidFallbackUrl,
-                        appsFlyer: appsFlyer
+                        appsFlyer: appsFlyer,
+                        attributionTtl: attributionTtl
                     ) { shortLinkData in
                         completion(shortLinkData)
                     }

--- a/AppsOnAir_AppLink/AppLinkService.swift
+++ b/AppsOnAir_AppLink/AppLinkService.swift
@@ -704,7 +704,7 @@ import Combine
                         Logger.logInternal(
                             "IP referral lookup failed for organic install, falling back to stored referral"
                         )
-                        completion(self.withAttribution(storedInfo))
+                        completion(self.withAttribution(rawReferralInfo))
                         return
                     }
 

--- a/AppsOnAir_AppLink/AppLinkService.swift
+++ b/AppsOnAir_AppLink/AppLinkService.swift
@@ -19,8 +19,8 @@ import Combine
             return appHelper.isAppFirstOpen
         }
 
-        /// Device's first install time
-        internal var firstInstallTime: String {
+        /// Device's first install time, as an epoch String
+        internal var firstInstallTime: String? {
             return appHelper.firstInstallTime
         }
 
@@ -40,10 +40,8 @@ import Combine
 
         private var latestReferralInfo: [String: Any]?
 
-        // "organic" / "nonorganic", computed only for the clipboard (advanced deferred link) approach.
-        // Defaults to organic (no referral found yet / error). Once a referral is found via the API
-        // without error, it becomes nonorganic — refined to organic/nonorganic by the click-time vs
-        // attributionTtl diff when that data is available.
+        // Attribution status: organic/non-organic; defaults to organic until resolved.
+
         private var latestAttributionStatus: String? = attributionStatusOrganic
 
         // Listener for whenever referral link is Update
@@ -52,10 +50,14 @@ import Combine
         // Manage for API call
         private let dispatchGroup = DispatchGroup()
 
+        private var attributionListener: (([String: Any]) -> Void)?
+        private var firstLaunchExpiredObserver: NSObjectProtocol?
+
         deinit {
             // Cancel the listener when the object is deallocated
             linkListener?.cancel()
             referralLinkListener?.cancel()
+            NotificationCenter.default.removeObserver(self)
         }
 
         /// Common initialization flow
@@ -69,6 +71,22 @@ import Combine
 
             // Initialize swizzling
             _ = AppSwizzler.shared
+
+            attributionListener = onAttributionListener
+            if let firstLaunchExpiredObserver {
+                NotificationCenter.default.removeObserver(firstLaunchExpiredObserver)
+            }
+            firstLaunchExpiredObserver = NotificationCenter.default.addObserver(
+                forName: .appsOnAirFirstLaunchDidExpire, object: nil, queue: .main
+            ) { [weak self] _ in
+                guard let self else { return }
+                Logger.logInternal(
+                    "AppLinkService: appsOnAirFirstLaunchDidExpire received, re-firing onAttributionListener"
+                )
+                self.getAttributionInfo { attributionInfo in
+                    self.attributionListener?(attributionInfo)
+                }
+            }
 
             // Listen for network status
             appsOnAirCoreServices.networkStatusListenerHandler { isConnected in
@@ -317,19 +335,24 @@ import Combine
                             appLinParams: appLinkReferralLinkParams,
                             isEnableAdvancedDeferredLink: true
                         ) { rawLinkInfo in
-                            let _ = self.appHelper.removeDataFromKeychain(key: referralData)
+                            _ = self.appHelper.removeDataFromKeychain(key: referralData)
 
-                            // isConsumed only takes effect starting the next app launch
-                            if (rawLinkInfo[statusCodeKey] as? Int) == 200 {
+                            var linkInfo = rawLinkInfo
+
+                            if (rawLinkInfo[statusCodeKey] as? Int) == successStatusCode {
+                                // isConsumed only takes effect starting the next app launch
                                 AppHelper.shared.isConsumed = true
                                 AppHelper.shared.userDefaults.set(true, forKey: isConsumedKey)
+
+                                linkInfo.removeValue(forKey: statusCodeKey)
                             }
 
-                            // strip the internal statusCode before storing/exposing to the host app
-                            var linkInfo = rawLinkInfo
-                            linkInfo.removeValue(forKey: statusCodeKey)
-
                             let referralStatus = linkInfo["status"] as? String
+
+                            self.latestReferralInfo = linkInfo
+                            self.appHelper.saveToKeychain(key: referralData, value: linkInfo)
+                            self.latestReferralURL = url
+
                             if referralStatus == "SUCCESS" {
                                 // clipboard-only: compare click time vs first install time vs attributionTtl
                                 self.computeAttributionStatus(
@@ -343,10 +366,6 @@ import Combine
                                     linkInfo[dataKey] = data
                                 }
                             }
-
-                            self.latestReferralInfo = linkInfo
-                            self.appHelper.saveToKeychain(key: referralData, value: linkInfo)
-                            self.latestReferralURL = url
 
                             if referralStatus == "SUCCESS" {
                                 AppLinkApiService.apiLinkAnalytics(
@@ -379,17 +398,18 @@ import Combine
                     } else {
                         Logger.logInternal("API called")
                         AppLinkApiService.apiReferralInfo { rawReferralLinkInfo in
-                            let _ = self.appHelper.removeDataFromKeychain(key: referralData)
+                            _ = self.appHelper.removeDataFromKeychain(key: referralData)
 
-                            // isConsumed only takes effect starting the next app launch
-                            if (rawReferralLinkInfo[statusCodeKey] as? Int) == 200 {
+                            var referralLinkInfo = rawReferralLinkInfo
+
+                            if (rawReferralLinkInfo[statusCodeKey] as? Int) == successStatusCode {
+
                                 AppHelper.shared.isConsumed = true
                                 AppHelper.shared.userDefaults.set(true, forKey: isConsumedKey)
-                            }
 
-                            // strip the internal statusCode before storing/exposing to the host app
-                            var referralLinkInfo = rawReferralLinkInfo
-                            referralLinkInfo.removeValue(forKey: statusCodeKey)
+                                // strip the internal statusCode before storing/exposing to the host app
+                                referralLinkInfo.removeValue(forKey: statusCodeKey)
+                            }
 
                             self.latestReferralInfo = referralLinkInfo
 
@@ -405,7 +425,7 @@ import Combine
                                 let referralURL = URL(string: referralLink),
                                 let domain = referralURL.host
                             {
-
+                                self.latestAttributionStatus = attributionStatusNonOrganic
                                 // Call analytics of referral result
                                 AppLinkApiService.apiLinkAnalytics(
                                     isClicked: false,
@@ -458,22 +478,22 @@ import Combine
         private func computeAttributionStatus(
             clickTimestamp: TimeInterval?, linkInfo: [String: Any]?
         ) {
-            // Referral was found via the API without error to get here — default to nonorganic,
-            // then refine to organic/nonorganic below if we have enough data to diff click time vs
-            // attributionTtl. (If the referral isn't found at all, this function never runs, and
-            // latestAttributionStatus keeps its class-level default: organic.)
+            // Referral found; default to non-organic and refine with click-time data.
             latestAttributionStatus = attributionStatusNonOrganic
 
-            guard let clickTimestamp = clickTimestamp else {
+            // Clipboard `applink_click_time` is in milliseconds.
+            guard let clickTimestampInMilliseconds = clickTimestamp else {
                 Logger.logInternal(
-                    "attributionStatus: no applink_click_time in clipboard — defaulting to nonorganic (referral found)"
+                    "attributionStatus: no applink_click_time in clipboard — defaulting to non-organic (referral found)"
                 )
                 return
             }
 
-            let data = linkInfo?["data"] as? [String: Any]
+            // Read TTL from response data when available; default to empty.
+            let data: [String: Any] = linkInfo?[dataKey] as? [String: Any] ?? [:]
+
             let rawAttributionTtl =
-                linkInfo?[attributionTtlResponseKey] ?? data?[attributionTtlResponseKey]
+                linkInfo?[attributionTtlResponseKey] ?? data[attributionTtlResponseKey]
 
             let attributionTtl: Double?
             switch rawAttributionTtl {
@@ -486,29 +506,26 @@ import Combine
 
             guard let attributionTtl = attributionTtl else {
                 Logger.logInternal(
-                    "attributionStatus: no attributionTtl in referral response (raw: \(String(describing: rawAttributionTtl))) — defaulting to nonorganic (referral found)"
+                    "attributionStatus: no attributionTtl in referral response (raw: \(String(describing: rawAttributionTtl))) — defaulting to non-organic (referral found)"
                 )
                 return
             }
 
-            let installDateFormatter = DateFormatter()
-            installDateFormatter.timeZone = TimeZone.current
-            installDateFormatter.locale = Locale(identifier: "en_US_POSIX")
-            installDateFormatter.dateFormat = "dd-MMM-yyyy hh:mm:ss a"
-
-            guard
-                let installDate = installDateFormatter.date(
-                    from: appHelper.getAppInstallationDate())
-            else {
+            guard let firstInstallEpoch = Double(appHelper.firstInstallTime ?? "") else {
                 Logger.logInternal(
-                    "attributionStatus: could not parse firstInstallTime — defaulting to nonorganic (referral found)"
+                    "attributionStatus: could not read firstInstallTime — defaulting to non-organic (referral found)"
                 )
                 return
             }
 
-            // convert firstInstallTime into epoch time to match clickTimestamp's units
-            let firstInstallEpoch = installDate.timeIntervalSince1970
-            let diffInSeconds = abs(clickTimestamp - firstInstallEpoch)
+            // scale the click time to epoch seconds so both sides use the same unit
+            let clickTimestampInSeconds: Double
+
+            let clickTimestampMeasurement = Measurement(
+                value: clickTimestampInMilliseconds, unit: UnitDuration.milliseconds)
+            clickTimestampInSeconds = clickTimestampMeasurement.converted(to: .seconds).value
+
+            let diffInSeconds = firstInstallEpoch - clickTimestampInSeconds
 
             latestAttributionStatus =
                 diffInSeconds > attributionTtl
@@ -541,9 +558,12 @@ import Combine
                 ? (self.latestReferralInfo ?? [:])
                 : (self.appHelper.readFromKeychain(key: referralData) ?? [:])
 
-            var data = attributionInfo[dataKey] as? [String: Any] ?? [:]
+            // Append attribution fields to response data.
+            var data: [String: Any] = attributionInfo[dataKey] as? [String: Any] ?? [:]
             data[isFirstLaunchKey] = self.isFirstLaunch
-            data[firstInstallTimeKey] = self.firstInstallTime
+            if let firstInstallTime = self.firstInstallTime {
+                data[firstInstallTimeKey] = firstInstallTime
+            }
             data[isConsumedKey] = self.isConsumed
             if let attributionStatus = self.latestAttributionStatus {
                 data[attributionStatusKey] = attributionStatus

--- a/AppsOnAir_AppLink/AppLinkWrapper.swift
+++ b/AppsOnAir_AppLink/AppLinkWrapper.swift
@@ -10,6 +10,9 @@ import Foundation
         /// Set up the SDK and start tracking app links and referral events.
         /// - Parameters:
         ///   - onDeepLinkProcessed: Callback invoked with the resolved deep link and its info.
+        ///   - onReferralLinkDetected: *(Deprecated)* Use `onAttributionListener` instead. Detection
+        ///     only — fires when a referral fetch actually runs, and receives the bare referral
+        ///     dictionary with `appsFlyer` removed.
         ///   - onAttributionListener: Fires at most twice — when a referral fetch actually runs
         ///     (first open, or no referral cached yet), then once more on the return to the
         ///     foreground that follows `isFirstLaunch` turning `false`, re-delivering the persisted
@@ -17,37 +20,11 @@ import Foundation
         ///     are silent. The payload includes the referral info plus `isFirstLaunch`,
         ///     `firstInstallTime`, `isConsumed`, and `attributionStatus` ("organic"/"non-organic")
         ///     — the last resolved status, restored from storage on later launches.
-        @objc(initializeWithOnDeepLinkProcessed:onAttributionListener:)
+        @objc(initializeWithOnDeepLinkProcessed:onReferralLinkDetected:onAttributionListener:)
         public class func initialize(
             withOnDeepLinkProcessed onDeepLinkProcessed: @escaping (URL?, NSDictionary) -> Void,
+            onReferralLinkDetected: ((NSDictionary) -> Void)? = nil,
             onAttributionListener: ((NSDictionary) -> Void)? = nil
-        ) {
-            AppLinkService.shared.initialize(
-                onDeepLinkProcessed: { url, info in
-                    onDeepLinkProcessed(url, info as NSDictionary)
-                },
-                onAttributionListener: { attributionInfo in
-                    onAttributionListener?(attributionInfo as NSDictionary)
-                })
-        }
-
-        /// - Parameters:
-        ///   - onDeepLinkProcessed: Callback invoked with the resolved deep link and its info.
-        ///   - onReferralLinkDetected: *(Deprecated)* Use `onAttributionListener` instead. Only fires
-        ///     when a referral fetch actually runs (first open, or no referral cached yet). Receives
-        ///     just the raw referral dictionary — use `initialize(withOnDeepLinkProcessed:onAttributionListener:)`
-        ///     for the referral info plus `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and
-        ///     `attributionStatus` ("organic"/"non-organic").
-        @available(
-            *,
-            deprecated,
-            message:
-                "`onReferralLinkDetected` is deprecated and will be removed in a future release. Use `onAttributionListener` instead."
-        )
-        @objc(initializeWithOnDeepLinkProcessed:onReferralLinkDetected:)
-        public class func initialize(
-            withOnDeepLinkProcessed onDeepLinkProcessed: @escaping (URL?, NSDictionary) -> Void,
-            onReferralLinkDetected: ((NSDictionary) -> Void)? = nil
         ) {
             AppLinkService.shared.initialize(
                 onDeepLinkProcessed: { url, info in
@@ -55,6 +32,9 @@ import Foundation
                 },
                 onReferralLinkDetected: { referralInfo in
                     onReferralLinkDetected?(referralInfo as NSDictionary)
+                },
+                onAttributionListener: { attributionInfo in
+                    onAttributionListener?(attributionInfo as NSDictionary)
                 })
         }
 

--- a/AppsOnAir_AppLink/AppLinkWrapper.swift
+++ b/AppsOnAir_AppLink/AppLinkWrapper.swift
@@ -8,6 +8,39 @@ import Foundation
     public class AppLinkWrapper: NSObject {
 
         /// Set up the SDK and start tracking app links and referral events.
+        /// - Parameters:
+        ///   - onDeepLinkProcessed: Callback invoked with the resolved deep link and its info.
+        ///   - onAttributionListener: Callback invoked when a referral fetch actually runs (first open,
+        ///     or no referral cached yet) — same trigger as `onReferralLinkDetected`. The payload
+        ///     includes the referral info plus `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and
+        ///     (clipboard/advanced deferred link approach only) `attributionStatus` ("organic"/"nonorganic").
+        @objc(initializeWithOnDeepLinkProcessed:onAttributionListener:)
+        public class func initialize(
+            withOnDeepLinkProcessed onDeepLinkProcessed: @escaping (URL?, NSDictionary) -> Void,
+            onAttributionListener: ((NSDictionary) -> Void)? = nil
+        ) {
+            AppLinkService.shared.initialize(
+                onDeepLinkProcessed: { url, info in
+                    onDeepLinkProcessed(url, info as NSDictionary)
+                },
+                onAttributionListener: { attributionInfo in
+                    onAttributionListener?(attributionInfo as NSDictionary)
+                })
+        }
+
+        /// - Parameters:
+        ///   - onDeepLinkProcessed: Callback invoked with the resolved deep link and its info.
+        ///   - onReferralLinkDetected: *(Deprecated)* Use `onAttributionListener` instead. Only fires
+        ///     when a referral fetch actually runs (first open, or no referral cached yet). Receives
+        ///     just the raw referral dictionary — use `initialize(withOnDeepLinkProcessed:onAttributionListener:)`
+        ///     for the referral info plus `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and
+        ///     (clipboard/advanced deferred link approach only) `attributionStatus` ("organic"/"nonorganic").
+        @available(
+            *,
+            deprecated,
+            message:
+                "`onReferralLinkDetected` is deprecated and will be removed in a future release. Use `onAttributionListener` instead."
+        )
         @objc(initializeWithOnDeepLinkProcessed:onReferralLinkDetected:)
         public class func initialize(
             withOnDeepLinkProcessed onDeepLinkProcessed: @escaping (URL?, NSDictionary) -> Void,
@@ -28,7 +61,8 @@ import Foundation
             AppLinkService.shared.handleAppLink(incomingURL: incomingURL)
         }
 
-        /// Get referral details
+        /// (Deprecated) Get referral info
+        @available(*, deprecated, renamed: "getAttributionInfo(withCompletion:)")
         @objc(getReferralInfoWithCompletion:)
         public class func getReferralInfo(
             withCompletion completion: @escaping (NSDictionary) -> Void
@@ -39,7 +73,7 @@ import Foundation
         }
 
         /// (Deprecated) Get referral details
-        @available(*, deprecated, renamed: "getReferralInfo(withCompletion:)")
+        @available(*, deprecated, renamed: "getAttributionInfo(withCompletion:)")
         @objc(getReferralDetailsWithCompletion:)
         public class func getReferralDetails(
             withCompletion completion: @escaping (NSDictionary) -> Void
@@ -49,11 +83,24 @@ import Foundation
             }
         }
 
+        /// Get referral/attribution info. Same as the deprecated `getReferralInfo`, with
+        /// `isFirstLaunch`, `firstInstallTime`, and `isConsumed` included in the response, plus
+        /// `attributionStatus` ("organic"/"nonorganic") when using the clipboard (advanced
+        /// deferred link) approach.
+        @objc(getAttributionInfoWithCompletion:)
+        public class func getAttributionInfo(
+            withCompletion completion: @escaping (NSDictionary) -> Void
+        ) {
+            AppLinkService.shared.getAttributionInfo { info in
+                completion(info as NSDictionary)
+            }
+        }
+
         /// Create a new AppLink
         @objc(
             createAppLinkWithUrl:name:urlPrefix:shortId:socialMeta:isOpenInBrowserApple:
             isOpenInIosApp:
-            iosFallbackUrl:isOpenInAndroidApp:isOpenInBrowserAndroid:androidFallbackUrl:appsFlyer:completion:
+            iosFallbackUrl:isOpenInAndroidApp:isOpenInBrowserAndroid:androidFallbackUrl:appsFlyer:attributionTtl:completion:
         )
         public class func createAppLink(
             url: String,
@@ -68,6 +115,7 @@ import Foundation
             isOpenInBrowserAndroid: NSNumber? = nil,
             androidFallbackUrl: String? = nil,
             appsFlyer: [String: Any]? = nil,
+            attributionTtl: NSNumber? = nil,
             completion: @escaping (NSDictionary) -> Void
         ) {
             let socialMetaSwift = socialMeta as? [String: Any]
@@ -83,7 +131,8 @@ import Foundation
                 isOpenInAndroidApp: isOpenInAndroidApp,
                 isOpenInBrowserAndroid: isOpenInBrowserAndroid,
                 androidFallbackUrl: androidFallbackUrl,
-                appsFlyer: appsFlyer
+                appsFlyer: appsFlyer,
+                attributionTtl: attributionTtl
             ) { result in
                 completion(result as NSDictionary)
             }

--- a/AppsOnAir_AppLink/AppLinkWrapper.swift
+++ b/AppsOnAir_AppLink/AppLinkWrapper.swift
@@ -13,7 +13,7 @@ import Foundation
         ///   - onAttributionListener: Callback invoked when a referral fetch actually runs (first open,
         ///     or no referral cached yet) — same trigger as `onReferralLinkDetected`. The payload
         ///     includes the referral info plus `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and
-        ///     (clipboard/advanced deferred link approach only) `attributionStatus` ("organic"/"nonorganic").
+        ///     (clipboard/advanced deferred link approach only) `attributionStatus` ("organic"/"non-organic").
         @objc(initializeWithOnDeepLinkProcessed:onAttributionListener:)
         public class func initialize(
             withOnDeepLinkProcessed onDeepLinkProcessed: @escaping (URL?, NSDictionary) -> Void,
@@ -34,7 +34,7 @@ import Foundation
         ///     when a referral fetch actually runs (first open, or no referral cached yet). Receives
         ///     just the raw referral dictionary — use `initialize(withOnDeepLinkProcessed:onAttributionListener:)`
         ///     for the referral info plus `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and
-        ///     (clipboard/advanced deferred link approach only) `attributionStatus` ("organic"/"nonorganic").
+        ///     (clipboard/advanced deferred link approach only) `attributionStatus` ("organic"/"non-organic").
         @available(
             *,
             deprecated,
@@ -85,7 +85,7 @@ import Foundation
 
         /// Get referral/attribution info. Same as the deprecated `getReferralInfo`, with
         /// `isFirstLaunch`, `firstInstallTime`, and `isConsumed` included in the response, plus
-        /// `attributionStatus` ("organic"/"nonorganic") when using the clipboard (advanced
+        /// `attributionStatus` ("organic"/"non-organic") when using the clipboard (advanced
         /// deferred link) approach.
         @objc(getAttributionInfoWithCompletion:)
         public class func getAttributionInfo(

--- a/AppsOnAir_AppLink/AppLinkWrapper.swift
+++ b/AppsOnAir_AppLink/AppLinkWrapper.swift
@@ -53,7 +53,7 @@ import Foundation
         @objc(
             createAppLinkWithUrl:name:urlPrefix:shortId:socialMeta:isOpenInBrowserApple:
             isOpenInIosApp:
-            iosFallbackUrl:isOpenInAndroidApp:isOpenInBrowserAndroid:androidFallbackUrl:completion:
+            iosFallbackUrl:isOpenInAndroidApp:isOpenInBrowserAndroid:androidFallbackUrl:appsFlyer:completion:
         )
         public class func createAppLink(
             url: String,
@@ -67,6 +67,7 @@ import Foundation
             isOpenInAndroidApp: NSNumber? = nil,
             isOpenInBrowserAndroid: NSNumber? = nil,
             androidFallbackUrl: String? = nil,
+            appsFlyer: [String: Any]? = nil,
             completion: @escaping (NSDictionary) -> Void
         ) {
             let socialMetaSwift = socialMeta as? [String: Any]
@@ -81,7 +82,8 @@ import Foundation
                 iosFallbackUrl: iosFallbackUrl,
                 isOpenInAndroidApp: isOpenInAndroidApp,
                 isOpenInBrowserAndroid: isOpenInBrowserAndroid,
-                androidFallbackUrl: androidFallbackUrl
+                androidFallbackUrl: androidFallbackUrl,
+                appsFlyer: appsFlyer
             ) { result in
                 completion(result as NSDictionary)
             }

--- a/AppsOnAir_AppLink/AppLinkWrapper.swift
+++ b/AppsOnAir_AppLink/AppLinkWrapper.swift
@@ -10,10 +10,13 @@ import Foundation
         /// Set up the SDK and start tracking app links and referral events.
         /// - Parameters:
         ///   - onDeepLinkProcessed: Callback invoked with the resolved deep link and its info.
-        ///   - onAttributionListener: Callback invoked when a referral fetch actually runs (first open,
-        ///     or no referral cached yet) — same trigger as `onReferralLinkDetected`. The payload
-        ///     includes the referral info plus `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and
-        ///     (clipboard/advanced deferred link approach only) `attributionStatus` ("organic"/"non-organic").
+        ///   - onAttributionListener: Fires at most twice — when a referral fetch actually runs
+        ///     (first open, or no referral cached yet), then once more on the return to the
+        ///     foreground that follows `isFirstLaunch` turning `false`, re-delivering the persisted
+        ///     payload without refetching so the listener sees that flip. Later foreground returns
+        ///     are silent. The payload includes the referral info plus `isFirstLaunch`,
+        ///     `firstInstallTime`, `isConsumed`, and `attributionStatus` ("organic"/"non-organic")
+        ///     — the last resolved status, restored from storage on later launches.
         @objc(initializeWithOnDeepLinkProcessed:onAttributionListener:)
         public class func initialize(
             withOnDeepLinkProcessed onDeepLinkProcessed: @escaping (URL?, NSDictionary) -> Void,
@@ -34,7 +37,7 @@ import Foundation
         ///     when a referral fetch actually runs (first open, or no referral cached yet). Receives
         ///     just the raw referral dictionary — use `initialize(withOnDeepLinkProcessed:onAttributionListener:)`
         ///     for the referral info plus `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and
-        ///     (clipboard/advanced deferred link approach only) `attributionStatus` ("organic"/"non-organic").
+        ///     `attributionStatus` ("organic"/"non-organic").
         @available(
             *,
             deprecated,
@@ -84,9 +87,9 @@ import Foundation
         }
 
         /// Get referral/attribution info. Same as the deprecated `getReferralInfo`, with
-        /// `isFirstLaunch`, `firstInstallTime`, and `isConsumed` included in the response, plus
-        /// `attributionStatus` ("organic"/"non-organic") when using the clipboard (advanced
-        /// deferred link) approach.
+        /// `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and `attributionStatus`
+        /// ("organic"/"non-organic") included in the response — the last resolved status,
+        /// restored from storage on later launches.
         @objc(getAttributionInfoWithCompletion:)
         public class func getAttributionInfo(
             withCompletion completion: @escaping (NSDictionary) -> Void

--- a/AppsOnAir_AppLink/EnvironmentConfig.swift
+++ b/AppsOnAir_AppLink/EnvironmentConfig.swift
@@ -1,15 +1,15 @@
-struct EnvironmentConfig{
-    
+struct EnvironmentConfig {
+
     // MARK: - Server API URL:
     static let serverBaseURl = "https://server.appsonair.link/api"
 
     // MARK: - API Endpoints:
-    
+
     static let createShortLink = serverBaseURl + "/dynamic-link"
-    
+
     static let getLinkInfo = createShortLink + "/"
-    
+
     static let getAnalytics = serverBaseURl + "/dynamic-link-analytics"
-    
-    static let getReferral  = createShortLink + "/referral/details"
+
+    static let getReferral = createShortLink + "/referral/details"
 }

--- a/AppsOnAir_AppLink/Resources/AppsOnAir-AppLinkInfo.plist
+++ b/AppsOnAir_AppLink/Resources/AppsOnAir-AppLinkInfo.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AppsOnAir_AppLink_ObjC/AppsOnAir_AppLink-Swift.m
+++ b/AppsOnAir_AppLink_ObjC/AppsOnAir_AppLink-Swift.m
@@ -19,6 +19,7 @@
           isOpenInAndroidApp:(nullable NSNumber *)isOpenInAndroidApp
       isOpenInBrowserAndroid:(nullable NSNumber *)isOpenInBrowserAndroid
           androidFallbackUrl:(nullable NSString *)androidFallbackUrl
+                   appsFlyer:(nullable NSDictionary *)appsFlyer
                   completion:(void (^)(NSDictionary *))completion;
 + (void)handleLaunchOptions:(NSDictionary *)launchOptions;
 + (void)continueUserActivity:(NSUserActivity *)userActivity;
@@ -86,6 +87,7 @@
           isOpenInAndroidApp:(nullable NSNumber *)isOpenInAndroidApp
       isOpenInBrowserAndroid:(nullable NSNumber *)isOpenInBrowserAndroid
           androidFallbackUrl:(nullable NSString *)androidFallbackUrl
+                   appsFlyer:(nullable NSDictionary *)appsFlyer
                   completion:(void (^)(NSDictionary *))completion {
   [AppLinkWrapper createAppLinkWithUrl:url
                                   name:name
@@ -98,6 +100,7 @@
                     isOpenInAndroidApp:isOpenInAndroidApp
                 isOpenInBrowserAndroid:isOpenInBrowserAndroid
                     androidFallbackUrl:androidFallbackUrl
+                             appsFlyer:appsFlyer
                             completion:completion];
 }
 
@@ -112,6 +115,7 @@
           isOpenInAndroidApp:(nullable NSNumber *)isOpenInAndroidApp
       isOpenInBrowserAndroid:(nullable NSNumber *)isOpenInBrowserAndroid
           androidFallbackUrl:(nullable NSString *)androidFallbackUrl
+                   appsFlyer:(nullable NSDictionary *)appsFlyer
                   completion:(void (^)(NSDictionary *))completion {
   [AppLinkService createAppLinkWithUrl:url
                                   name:name
@@ -124,6 +128,7 @@
                     isOpenInAndroidApp:isOpenInAndroidApp
                 isOpenInBrowserAndroid:isOpenInBrowserAndroid
                     androidFallbackUrl:androidFallbackUrl
+                             appsFlyer:appsFlyer
                             completion:completion];
 }
 

--- a/AppsOnAir_AppLink_ObjC/AppsOnAir_AppLink-Swift.m
+++ b/AppsOnAir_AppLink_ObjC/AppsOnAir_AppLink-Swift.m
@@ -3,11 +3,16 @@
 @interface AppLinkWrapper : NSObject
 + (void)initializeWithOnDeepLinkProcessed:
             (void (^)(NSURL *_Nullable, NSDictionary *))onDeepLinkProcessed
+                    onAttributionListener:
+                        (nullable void (^)(NSDictionary *))onAttributionListener;
++ (void)initializeWithOnDeepLinkProcessed:
+            (void (^)(NSURL *_Nullable, NSDictionary *))onDeepLinkProcessed
                    onReferralLinkDetected:
                        (nullable void (^)(NSDictionary *))onReferralLinkDetected;
 + (void)handleAppLinkWithURL:(NSURL *)url;
 + (void)getReferralInfoWithCompletion:(void (^)(NSDictionary *))completion;
 + (void)getReferralDetailsWithCompletion:(void (^)(NSDictionary *))completion;
++ (void)getAttributionInfoWithCompletion:(void (^)(NSDictionary *))completion;
 + (void)createAppLinkWithUrl:(NSString *)url
                         name:(NSString *)name
                    urlPrefix:(NSString *)urlPrefix
@@ -20,6 +25,7 @@
       isOpenInBrowserAndroid:(nullable NSNumber *)isOpenInBrowserAndroid
           androidFallbackUrl:(nullable NSString *)androidFallbackUrl
                    appsFlyer:(nullable NSDictionary *)appsFlyer
+              attributionTtl:(nullable NSNumber *)attributionTtl
                   completion:(void (^)(NSDictionary *))completion;
 + (void)handleLaunchOptions:(NSDictionary *)launchOptions;
 + (void)continueUserActivity:(NSUserActivity *)userActivity;
@@ -34,6 +40,22 @@
     instance = [[self alloc] init];
   });
   return instance;
+}
+
++ (void)initializeOnDeepLinkProcessed:
+            (void (^)(NSURL *_Nullable, NSDictionary *))onDeepLinkProcessed
+                onAttributionListener:(nullable void (^)(NSDictionary *))
+                                          onAttributionListener {
+  [AppLinkWrapper initializeWithOnDeepLinkProcessed:onDeepLinkProcessed
+                              onAttributionListener:onAttributionListener];
+}
+
+- (void)initializeOnDeepLinkProcessed:
+            (void (^)(NSURL *_Nullable, NSDictionary *))onDeepLinkProcessed
+                onAttributionListener:(nullable void (^)(NSDictionary *))
+                                          onAttributionListener {
+  [AppLinkWrapper initializeWithOnDeepLinkProcessed:onDeepLinkProcessed
+                              onAttributionListener:onAttributionListener];
 }
 
 + (void)initializeOnDeepLinkProcessed:
@@ -76,6 +98,14 @@
   [AppLinkWrapper getReferralDetailsWithCompletion:completion];
 }
 
++ (void)getAttributionInfoWithCompletion:(void (^)(NSDictionary *))completion {
+  [AppLinkWrapper getAttributionInfoWithCompletion:completion];
+}
+
+- (void)getAttributionInfoWithCompletion:(void (^)(NSDictionary *))completion {
+  [AppLinkWrapper getAttributionInfoWithCompletion:completion];
+}
+
 + (void)createAppLinkWithUrl:(NSString *)url
                         name:(NSString *)name
                    urlPrefix:(NSString *)urlPrefix
@@ -88,6 +118,7 @@
       isOpenInBrowserAndroid:(nullable NSNumber *)isOpenInBrowserAndroid
           androidFallbackUrl:(nullable NSString *)androidFallbackUrl
                    appsFlyer:(nullable NSDictionary *)appsFlyer
+              attributionTtl:(nullable NSNumber *)attributionTtl
                   completion:(void (^)(NSDictionary *))completion {
   [AppLinkWrapper createAppLinkWithUrl:url
                                   name:name
@@ -101,6 +132,7 @@
                 isOpenInBrowserAndroid:isOpenInBrowserAndroid
                     androidFallbackUrl:androidFallbackUrl
                              appsFlyer:appsFlyer
+                       attributionTtl:attributionTtl
                             completion:completion];
 }
 
@@ -116,6 +148,7 @@
       isOpenInBrowserAndroid:(nullable NSNumber *)isOpenInBrowserAndroid
           androidFallbackUrl:(nullable NSString *)androidFallbackUrl
                    appsFlyer:(nullable NSDictionary *)appsFlyer
+              attributionTtl:(nullable NSNumber *)attributionTtl
                   completion:(void (^)(NSDictionary *))completion {
   [AppLinkService createAppLinkWithUrl:url
                                   name:name
@@ -129,6 +162,7 @@
                 isOpenInBrowserAndroid:isOpenInBrowserAndroid
                     androidFallbackUrl:androidFallbackUrl
                              appsFlyer:appsFlyer
+                       attributionTtl:attributionTtl
                             completion:completion];
 }
 

--- a/AppsOnAir_AppLink_ObjC/include/AppsOnAir_AppLink/AppsOnAir_AppLink-Swift.h
+++ b/AppsOnAir_AppLink_ObjC/include/AppsOnAir_AppLink/AppsOnAir_AppLink-Swift.h
@@ -8,9 +8,12 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)shared;
 
 /// Set up the SDK and start tracking app links and referral events.
-/// `onAttributionListener` fires when a referral fetch actually runs (first open,
-/// or no referral cached yet), with `isFirstLaunch`, `firstInstallTime`,
-/// `isConsumed`, and `attributionStatus` included in its payload.
+/// `onAttributionListener` fires at most twice: when a referral fetch actually
+/// runs (first open, or no referral cached yet), then once more on the return to
+/// the foreground that follows `isFirstLaunch` turning `NO`, re-delivering the
+/// persisted payload without refetching. Later foreground returns are silent.
+/// `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and `attributionStatus`
+/// are included in its payload.
 - (void)initializeOnDeepLinkProcessed:
             (void (^)(NSURL *_Nullable url,
                       NSDictionary *info))onDeepLinkProcessed
@@ -45,6 +48,10 @@ NS_ASSUME_NONNULL_BEGIN
     (void (^)(NSDictionary *info))completion __attribute__((
         deprecated("Use getAttributionInfoWithCompletion: instead")));
 
+/// Get referral and attribution info. Same as the deprecated `getReferralInfo`,
+/// with `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and
+/// `attributionStatus` ("organic"/"non-organic") included in the response —
+/// the last resolved status, restored from storage on later launches.
 - (void)getAttributionInfoWithCompletion:
     (void (^)(NSDictionary *info))completion;
 

--- a/AppsOnAir_AppLink_ObjC/include/AppsOnAir_AppLink/AppsOnAir_AppLink-Swift.h
+++ b/AppsOnAir_AppLink_ObjC/include/AppsOnAir_AppLink/AppsOnAir_AppLink-Swift.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
           isOpenInAndroidApp:(nullable NSNumber *)isOpenInAndroidApp
       isOpenInBrowserAndroid:(nullable NSNumber *)isOpenInBrowserAndroid
           androidFallbackUrl:(nullable NSString *)androidFallbackUrl
+                   appsFlyer:(nullable NSDictionary *)appsFlyer
                   completion:(void (^)(NSDictionary *result))completion;
 
 /// Handles app launch initiated from a cold start via a custom URL scheme.

--- a/AppsOnAir_AppLink_ObjC/include/AppsOnAir_AppLink/AppsOnAir_AppLink-Swift.h
+++ b/AppsOnAir_AppLink_ObjC/include/AppsOnAir_AppLink/AppsOnAir_AppLink-Swift.h
@@ -8,22 +8,45 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)shared;
 
 /// Set up the SDK and start tracking app links and referral events.
+/// `onAttributionListener` fires when a referral fetch actually runs (first open,
+/// or no referral cached yet), with `isFirstLaunch`, `firstInstallTime`,
+/// `isConsumed`, and `attributionStatus` included in its payload.
 - (void)initializeOnDeepLinkProcessed:
             (void (^)(NSURL *_Nullable url,
                       NSDictionary *info))onDeepLinkProcessed
-                onReferralLinkDetected:
-                    (nullable void (^)(NSDictionary *referralInfo))
-                        onReferralLinkDetected;
+                onAttributionListener:
+                    (nullable void (^)(NSDictionary *attributionInfo))
+                        onAttributionListener;
+
+/// (Deprecated) Use `initializeOnDeepLinkProcessed:onAttributionListener:`
+/// instead. Receives just the raw referral dictionary — the deprecated
+/// replacement also includes `isFirstLaunch`, `firstInstallTime`,
+/// `isConsumed`, and `attributionStatus`.
+- (void)initializeOnDeepLinkProcessed:
+            (void (^)(NSURL *_Nullable url,
+                      NSDictionary *info))onDeepLinkProcessed
+               onReferralLinkDetected:
+                   (nullable void (^)(NSDictionary *referralInfo))
+                       onReferralLinkDetected
+    __attribute__((
+        deprecated("onReferralLinkDetected is deprecated and will be removed "
+                   "in a future release. Use onAttributionListener instead.")));
 
 /// Handle incoming URLs, including custom scheme and universal links.
 - (void)handleAppLinkWithIncomingURL:(NSURL *)url;
 
-/// Get referral details.
-- (void)getReferralInfoWithCompletion:(void (^)(NSDictionary *info))completion;
+/// (Deprecated) Get referral info.
+- (void)getReferralInfoWithCompletion:(void (^)(NSDictionary *info))completion
+    __attribute__((
+        deprecated("Use getAttributionInfoWithCompletion: instead")));
 
 /// (Deprecated) Get referral details.
-- (void)getReferralDetailsWithCompletion:(void (^)(NSDictionary *info))completion
-    __attribute__((deprecated("Use getReferralInfoWithCompletion: instead")));
+- (void)getReferralDetailsWithCompletion:
+    (void (^)(NSDictionary *info))completion __attribute__((
+        deprecated("Use getAttributionInfoWithCompletion: instead")));
+
+- (void)getAttributionInfoWithCompletion:
+    (void (^)(NSDictionary *info))completion;
 
 /// Create a new AppLink.
 - (void)createAppLinkWithUrl:(NSString *)url
@@ -38,6 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
       isOpenInBrowserAndroid:(nullable NSNumber *)isOpenInBrowserAndroid
           androidFallbackUrl:(nullable NSString *)androidFallbackUrl
                    appsFlyer:(nullable NSDictionary *)appsFlyer
+              attributionTtl:(nullable NSNumber *)attributionTtl
                   completion:(void (^)(NSDictionary *result))completion;
 
 /// Handles app launch initiated from a cold start via a custom URL scheme.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.0
+
+**New method and listener:** 
+* Added `getAttributionInfo`/`onAttributionListener`, returning `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and `attributionStatus` (`"organic"`/`"non-organic"`) alongside referral data.
+* Deprecated `getReferralInfo` and `onReferralLinkDetected` in favor of `getAttributionInfo`/`onAttributionListener`.
+* `createAppLink()` now supports `appsFlyer` and `attributionTtl` params.
+
 ## 1.4.1
 
 * Minor fixes and improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **New method and listener:** 
 * Added `getAttributionInfo`/`onAttributionListener`, returning `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and `attributionStatus` (`"organic"`/`"non-organic"`) alongside referral data.
+* `onAttributionListener` fires at most twice: at first detection, then once more on the return to the foreground that follows `isFirstLaunch` turning `false` (reading persisted state, no refetch). Later foreground returns are silent. Matches the Android SDK. `onReferralLinkDetected` keeps its detection-only behaviour.
 * Deprecated `getReferralInfo` and `onReferralLinkDetected` in favor of `getAttributionInfo`/`onAttributionListener`.
 * `createAppLink()` now supports `appsFlyer` and `attributionTtl` params.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 ## 2.0.0
 
-**New method and listener:** 
-* Added `getAttributionInfo`/`onAttributionListener`, returning `isFirstLaunch`, `firstInstallTime`, `isConsumed`, and `attributionStatus` (`"organic"`/`"non-organic"`) alongside referral data.
-* `onAttributionListener` fires at most twice: at first detection, then once more on the return to the foreground that follows `isFirstLaunch` turning `false` (reading persisted state, no refetch). Later foreground returns are silent. Matches the Android SDK. `onReferralLinkDetected` keeps its detection-only behaviour.
-* Deprecated `getReferralInfo` and `onReferralLinkDetected` in favor of `getAttributionInfo`/`onAttributionListener`.
-* `createAppLink()` now supports `appsFlyer` and `attributionTtl` params.
+* `getReferralInfo()` is now deprecated, use `getAttributionInfo()` instead.
+
+* Introduced `getAttributionInfo()` method.
+    * Returns the same data as `getReferralInfo()` with additional `isFirstLaunch`, `firstInstallTime`, `isConsumed` and `attributionStatus` fields included in the response.
+
+* Introduced `onAttributionListener()` listener.
+    * When an attribution is detected, and again every time the app returns to the foreground so the payload stays current.
+
+* Added `appsFlyer` and `attributionTtl` params to `AppLinkParams` for AppsFlyer attribution support in `createAppLink` method.
+
+**Deprecated:**
+
+* `onReferralLinkDetected()` — use `onAttributionListener()`.
+* `getReferralInfo()` and `getReferralDetails()` — use `getAttributionInfo()`.
 
 ## 1.4.1
 

--- a/Example/AppsOnAir-AppLink.xcodeproj/project.pbxproj
+++ b/Example/AppsOnAir-AppLink.xcodeproj/project.pbxproj
@@ -7,14 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3CB6000BF113935163641774 /* Pods_AppsOnAir_AppLink_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9D2492C1F0058D38CB0AD1A /* Pods_AppsOnAir_AppLink_Example.framework */; };
-		4A5432A2460C101BCFDC613C /* Pods_AppsOnAir_AppLink_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4074D8E8DEE7EF32D9A77460 /* Pods_AppsOnAir_AppLink_Tests.framework */; };
+		4687D0EBC305867A38ED7CD1 /* Pods_AppsOnAir_AppLink_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E13150BE4ECC9103B25B71A3 /* Pods_AppsOnAir_AppLink_Tests.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
+		7F7CA8885DA1B77DC4A8ADD2 /* Pods_AppsOnAir_AppLink_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F89CD95F0957DF5926208E7 /* Pods_AppsOnAir_AppLink_Example.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -28,7 +28,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		4074D8E8DEE7EF32D9A77460 /* Pods_AppsOnAir_AppLink_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppsOnAir_AppLink_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0F89CD95F0957DF5926208E7 /* Pods_AppsOnAir_AppLink_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppsOnAir_AppLink_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		490D4A3E6AC12F83D6CDA2A9 /* AppsOnAir-AppLink.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = "AppsOnAir-AppLink.podspec"; path = "../AppsOnAir-AppLink.podspec"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		607FACD01AFB9204008FA782 /* AppsOnAir-AppLink_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "AppsOnAir-AppLink_Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -40,14 +40,14 @@
 		607FACE51AFB9204008FA782 /* AppsOnAir-AppLink_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AppsOnAir-AppLink_Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACEB1AFB9204008FA782 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
-		7A7083D659BF437A143E9E07 /* Pods-AppsOnAir-AppLink_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsOnAir-AppLink_Example.release.xcconfig"; path = "Target Support Files/Pods-AppsOnAir-AppLink_Example/Pods-AppsOnAir-AppLink_Example.release.xcconfig"; sourceTree = "<group>"; };
+		88BC08415BABA8450CD3BEC1 /* Pods-AppsOnAir-AppLink_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsOnAir-AppLink_Example.release.xcconfig"; path = "Target Support Files/Pods-AppsOnAir-AppLink_Example/Pods-AppsOnAir-AppLink_Example.release.xcconfig"; sourceTree = "<group>"; };
 		B6C2A15E2DDF589D0005025E /* AppsOnAir-AppLink_Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "AppsOnAir-AppLink_Example.entitlements"; sourceTree = "<group>"; };
-		B8D48B413349F3028FD7F91D /* Pods-AppsOnAir-AppLink_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsOnAir-AppLink_Tests.debug.xcconfig"; path = "Target Support Files/Pods-AppsOnAir-AppLink_Tests/Pods-AppsOnAir-AppLink_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		C9D2492C1F0058D38CB0AD1A /* Pods_AppsOnAir_AppLink_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppsOnAir_AppLink_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CBD7772B52F60638C63899A5 /* Pods-AppsOnAir-AppLink_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsOnAir-AppLink_Tests.release.xcconfig"; path = "Target Support Files/Pods-AppsOnAir-AppLink_Tests/Pods-AppsOnAir-AppLink_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		C4C4DF763D01910419455BF7 /* Pods-AppsOnAir-AppLink_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsOnAir-AppLink_Tests.debug.xcconfig"; path = "Target Support Files/Pods-AppsOnAir-AppLink_Tests/Pods-AppsOnAir-AppLink_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		D0E135F8DE273BFA6C6CADA9 /* Pods-AppsOnAir-AppLink_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsOnAir-AppLink_Example.debug.xcconfig"; path = "Target Support Files/Pods-AppsOnAir-AppLink_Example/Pods-AppsOnAir-AppLink_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		D909F9407C20F73AA7DC9484 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
-		DFACD81C0AD5391393ACF18E /* Pods-AppsOnAir-AppLink_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsOnAir-AppLink_Example.debug.xcconfig"; path = "Target Support Files/Pods-AppsOnAir-AppLink_Example/Pods-AppsOnAir-AppLink_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		E13150BE4ECC9103B25B71A3 /* Pods_AppsOnAir_AppLink_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AppsOnAir_AppLink_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC0162ED39D858752ADD8E2F /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		F7B3F1AB009ED2B88D7A855B /* Pods-AppsOnAir-AppLink_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsOnAir-AppLink_Tests.release.xcconfig"; path = "Target Support Files/Pods-AppsOnAir-AppLink_Tests/Pods-AppsOnAir-AppLink_Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,7 +55,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3CB6000BF113935163641774 /* Pods_AppsOnAir_AppLink_Example.framework in Frameworks */,
+				7F7CA8885DA1B77DC4A8ADD2 /* Pods_AppsOnAir_AppLink_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -63,7 +63,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4A5432A2460C101BCFDC613C /* Pods_AppsOnAir_AppLink_Tests.framework in Frameworks */,
+				4687D0EBC305867A38ED7CD1 /* Pods_AppsOnAir_AppLink_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -73,21 +73,12 @@
 		478F172690B18CDC9B973E15 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				DFACD81C0AD5391393ACF18E /* Pods-AppsOnAir-AppLink_Example.debug.xcconfig */,
-				7A7083D659BF437A143E9E07 /* Pods-AppsOnAir-AppLink_Example.release.xcconfig */,
-				B8D48B413349F3028FD7F91D /* Pods-AppsOnAir-AppLink_Tests.debug.xcconfig */,
-				CBD7772B52F60638C63899A5 /* Pods-AppsOnAir-AppLink_Tests.release.xcconfig */,
+				D0E135F8DE273BFA6C6CADA9 /* Pods-AppsOnAir-AppLink_Example.debug.xcconfig */,
+				88BC08415BABA8450CD3BEC1 /* Pods-AppsOnAir-AppLink_Example.release.xcconfig */,
+				C4C4DF763D01910419455BF7 /* Pods-AppsOnAir-AppLink_Tests.debug.xcconfig */,
+				F7B3F1AB009ED2B88D7A855B /* Pods-AppsOnAir-AppLink_Tests.release.xcconfig */,
 			);
 			path = Pods;
-			sourceTree = "<group>";
-		};
-		49E84F289C743D8323668D64 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				C9D2492C1F0058D38CB0AD1A /* Pods_AppsOnAir_AppLink_Example.framework */,
-				4074D8E8DEE7EF32D9A77460 /* Pods_AppsOnAir_AppLink_Tests.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		607FACC71AFB9204008FA782 = {
@@ -99,7 +90,7 @@
 				607FACE81AFB9204008FA782 /* Tests */,
 				607FACD11AFB9204008FA782 /* Products */,
 				478F172690B18CDC9B973E15 /* Pods */,
-				49E84F289C743D8323668D64 /* Frameworks */,
+				F58D72D53CA5142C21729901 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -161,6 +152,15 @@
 			name = "Podspec Metadata";
 			sourceTree = "<group>";
 		};
+		F58D72D53CA5142C21729901 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0F89CD95F0957DF5926208E7 /* Pods_AppsOnAir_AppLink_Example.framework */,
+				E13150BE4ECC9103B25B71A3 /* Pods_AppsOnAir_AppLink_Tests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -168,11 +168,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACEF1AFB9204008FA782 /* Build configuration list for PBXNativeTarget "AppsOnAir-AppLink_Example" */;
 			buildPhases = (
-				13512E6D6B7FD9ABF923C39A /* [CP] Check Pods Manifest.lock */,
+				289760F90F9DBC73D6D3F064 /* [CP] Check Pods Manifest.lock */,
 				607FACCC1AFB9204008FA782 /* Sources */,
 				607FACCD1AFB9204008FA782 /* Frameworks */,
 				607FACCE1AFB9204008FA782 /* Resources */,
-				21F95208835F91EF301301E0 /* [CP] Embed Pods Frameworks */,
+				F0DC786894ABBF3D62DC4F5C /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -187,7 +187,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACF21AFB9204008FA782 /* Build configuration list for PBXNativeTarget "AppsOnAir-AppLink_Tests" */;
 			buildPhases = (
-				F35A6C9FFE89F70616CAA000 /* [CP] Check Pods Manifest.lock */,
+				D70683327BDC7B0E6FBF0BBD /* [CP] Check Pods Manifest.lock */,
 				607FACE11AFB9204008FA782 /* Sources */,
 				607FACE21AFB9204008FA782 /* Frameworks */,
 				607FACE31AFB9204008FA782 /* Resources */,
@@ -266,7 +266,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		13512E6D6B7FD9ABF923C39A /* [CP] Check Pods Manifest.lock */ = {
+		289760F90F9DBC73D6D3F064 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -288,29 +288,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		21F95208835F91EF301301E0 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AppsOnAir-AppLink_Example/Pods-AppsOnAir-AppLink_Example-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/AppsOnAir-AppLink/AppsOnAir_AppLink.framework",
-				"${BUILT_PRODUCTS_DIR}/AppsOnAir-Core/AppsOnAir_Core.framework",
-				"${BUILT_PRODUCTS_DIR}/ReachabilitySwift/Reachability.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AppsOnAir_AppLink.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AppsOnAir_Core.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AppsOnAir-AppLink_Example/Pods-AppsOnAir-AppLink_Example-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F35A6C9FFE89F70616CAA000 /* [CP] Check Pods Manifest.lock */ = {
+		D70683327BDC7B0E6FBF0BBD /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -330,6 +308,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F0DC786894ABBF3D62DC4F5C /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AppsOnAir-AppLink_Example/Pods-AppsOnAir-AppLink_Example-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/AppsOnAir-AppLink/AppsOnAir_AppLink.framework",
+				"${BUILT_PRODUCTS_DIR}/AppsOnAir-Core/AppsOnAir_Core.framework",
+				"${BUILT_PRODUCTS_DIR}/ReachabilitySwift/Reachability.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AppsOnAir_AppLink.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AppsOnAir_Core.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AppsOnAir-AppLink_Example/Pods-AppsOnAir-AppLink_Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -483,7 +483,7 @@
 		};
 		607FACF01AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DFACD81C0AD5391393ACF18E /* Pods-AppsOnAir-AppLink_Example.debug.xcconfig */;
+			baseConfigurationReference = D0E135F8DE273BFA6C6CADA9 /* Pods-AppsOnAir-AppLink_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "AppsOnAir-AppLink_Example.entitlements";
@@ -503,7 +503,7 @@
 		};
 		607FACF11AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7A7083D659BF437A143E9E07 /* Pods-AppsOnAir-AppLink_Example.release.xcconfig */;
+			baseConfigurationReference = 88BC08415BABA8450CD3BEC1 /* Pods-AppsOnAir-AppLink_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "AppsOnAir-AppLink_Example.entitlements";
@@ -523,7 +523,7 @@
 		};
 		607FACF31AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B8D48B413349F3028FD7F91D /* Pods-AppsOnAir-AppLink_Tests.debug.xcconfig */;
+			baseConfigurationReference = C4C4DF763D01910419455BF7 /* Pods-AppsOnAir-AppLink_Tests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
@@ -549,7 +549,7 @@
 		};
 		607FACF41AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CBD7772B52F60638C63899A5 /* Pods-AppsOnAir-AppLink_Tests.release.xcconfig */;
+			baseConfigurationReference = F7B3F1AB009ED2B88D7A855B /* Pods-AppsOnAir-AppLink_Tests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";

--- a/Example/AppsOnAir-AppLink/AppDelegate.swift
+++ b/Example/AppsOnAir-AppLink/AppDelegate.swift
@@ -6,14 +6,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let appLinkService = AppLinkService.shared
     var window: UIWindow?
 
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
-        appLinkService.initialize { url, linkInfo in
-            // write the code for handling flow based on url
-        } onAttributionListener: { attributionInfo in
-            // write the code for handling attribution flow based on url
-        }
+        // One call registers every callback. onReferralLinkDetected is deprecated and kept here
+        // only to compare its payload with onAttributionListener: it is detection-only and drops
+        // `appsFlyer` and the attribution fields.
+        // Initialize the AppLink to track the deeplink and attribution tracking.
+        appLinkService.initialize(
+            onDeepLinkProcessed: { url, linkInfo in
+              // write the code for handling onDeepLinkProcessed flow based on url
+            },
+            onReferralLinkDetected: { referralInfo in
+                                 // write the code for handling onReferralLinkDetected flow based on referralInfo
+               },
+            onAttributionListener: { attributionInfo in
+                            // write the code for handling onAttributionListener flow based on attributionInfo
+
+            })
+        
         return true
     }
     

--- a/Example/AppsOnAir-AppLink/AppDelegate.swift
+++ b/Example/AppsOnAir-AppLink/AppDelegate.swift
@@ -1,5 +1,5 @@
-import UIKit
 import AppsOnAir_AppLink
+import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -11,8 +11,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         appLinkService.initialize { url, linkInfo in
             // write the code for handling flow based on url
-        } onReferralLinkDetected: { referralInfo in
-            // write the code for handling referral flow based on url
+        } onAttributionListener: { attributionInfo in
+            // write the code for handling attribution flow based on url
         }
         return true
     }
@@ -44,6 +44,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
-
 }
-

--- a/Example/AppsOnAir-AppLink/ViewController.swift
+++ b/Example/AppsOnAir-AppLink/ViewController.swift
@@ -29,9 +29,17 @@ class ViewController: UIViewController {
 
     @objc func createLinkTapped() {
 
+        //Help to get attribution information
+        appLinkService.getAttributionInfo { attributionInfo in
+            //Write code for handle attribution info
+        }
+
         //Help to get referral information
-        appLinkService.getReferralInfo { referralLinkInfo in
-            //Write code for handle referral link information
+        appLinkService.getReferralInfo { referralInfo in
+            //Write code for handle referral info
+        }
+        appLinkService.getReferralDetails { referralInfo in
+            //Write code for handle referral info
         }
 
         //help to set social meta
@@ -56,7 +64,7 @@ class ViewController: UIViewController {
             url: "https://appsonair.com", name: "AppsOnAir",
             urlPrefix: "YOUR_DOMAIN_NAME", shortId: "LINK_ID",
             socialMeta: socialMeta, isOpenInBrowserApple: false, isOpenInIosApp: true,
-            iosFallbackUrl: "https://appstore.com", appsFlyer: appsFlyer
+            iosFallbackUrl: "https://appstore.com", appsFlyer: appsFlyer, attributionTtl: 3600
         ) { linkInfo in
             //write code for handle create link
         }

--- a/Example/AppsOnAir-AppLink/ViewController.swift
+++ b/Example/AppsOnAir-AppLink/ViewController.swift
@@ -1,11 +1,11 @@
-import UIKit
 import AppsOnAir_AppLink
+import UIKit
 
 class ViewController: UIViewController {
     let appLinkService = AppLinkService.shared
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         // Create the button
         let createLinkButton = UIButton(type: .system)
         createLinkButton.setTitle("Create Link", for: .normal)
@@ -23,25 +23,42 @@ class ViewController: UIViewController {
             createLinkButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             createLinkButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             createLinkButton.widthAnchor.constraint(equalToConstant: 200),
-            createLinkButton.heightAnchor.constraint(equalToConstant: 50)
+            createLinkButton.heightAnchor.constraint(equalToConstant: 50),
         ])
     }
 
     @objc func createLinkTapped() {
-        
-        //Help to get referral information 
+
+        //Help to get referral information
         appLinkService.getReferralInfo { referralLinkInfo in
             //Write code for handle referral link information
         }
-        
+
         //help to set social meta
-        let socialMeta = ["imageUrl":"https://image.png","title":"link title","description":"link description"]
-        
+        let socialMeta = [
+            "imageUrl": "https://image.png", "title": "link title",
+            "description": "link description",
+        ]
+
+        //help to set AppsFlyer attribution params
+        let appsFlyer: [String: Any] = [
+            "channel": "appsonair",
+            "campaignId": "01",
+            "campaign": "test",
+            "subs": ["sub1", "sub2", "sub3", "sub4", "sub5"],
+            "metaTitle": "metaTitle",
+            "metaDescription": "metaDescription",
+        ]
+
         //help to create appLink
         // <urlPrefix> shouldn't contain http or https
-        appLinkService.createAppLink(url: "https://appsonair.com", name: "AppsOnAir", urlPrefix: "YOUR_DOMAIN_NAME",shortId: "LINK_ID",socialMeta: socialMeta, isOpenInBrowserApple: false,isOpenInIosApp: true,iosFallbackUrl: "https://appstore.com") { linkInfo in
+        appLinkService.createAppLink(
+            url: "https://appsonair.com", name: "AppsOnAir",
+            urlPrefix: "YOUR_DOMAIN_NAME", shortId: "LINK_ID",
+            socialMeta: socialMeta, isOpenInBrowserApple: false, isOpenInIosApp: true,
+            iosFallbackUrl: "https://appstore.com", appsFlyer: appsFlyer
+        ) { linkInfo in
             //write code for handle create link
         }
     }
 }
-

--- a/Example/AppsOnAir-AppLink/ViewController.swift
+++ b/Example/AppsOnAir-AppLink/ViewController.swift
@@ -3,44 +3,383 @@ import UIKit
 
 class ViewController: UIViewController {
     let appLinkService = AppLinkService.shared
+
+    private let contentStack = UIStackView()
+    private var sectionViews: [ResponseSection: ResponseSectionView] = [:]
+
+    // createAppLink inputs, mirroring the React Native example's form.
+    private let nameField = UITextField()
+    private let urlField = UITextField()
+    private let urlPrefixField = UITextField()
+    private let shortIdField = UITextField()
+    private let androidFallbackField = UITextField()
+    private let iosFallbackField = UITextField()
+    private let attributionTtlField = UITextField()
+    private let appsFlyerView = UITextView()
+    private let openInAndroidAppSwitch = UISwitch()
+    private let openInAndroidBrowserSwitch = UISwitch()
+    private let openInIosAppSwitch = UISwitch()
+    private let openInAppleBrowserSwitch = UISwitch()
+
+    /// The SDK forwards this dictionary to the API untouched, so it is edited as raw JSON rather
+    /// than fixed fields — any keys beyond the documented ones are passed through as-is.
+    private let defaultAppsFlyerJSON = """
+        {
+          "channel": "appsonair",
+          "campaignId": "01",
+          "campaign": "test",
+          "subs": ["sub1", "sub2", "sub3", "sub4", "sub5"],
+          "metaTitle": "metaTitle",
+          "metaDescription": "metaDescription"
+        }
+        """
+
+    private let loaderOverlay = UIView()
+    private let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .whiteLarge)
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Create the button
-        let createLinkButton = UIButton(type: .system)
-        createLinkButton.setTitle("Create Link", for: .normal)
-        createLinkButton.setTitleColor(.white, for: .normal)
-        createLinkButton.backgroundColor = .systemBlue
-        createLinkButton.layer.cornerRadius = 10
-        createLinkButton.translatesAutoresizingMaskIntoConstraints = false
-        createLinkButton.addTarget(self, action: #selector(createLinkTapped), for: .touchUpInside)
+        view.backgroundColor = .white
+        setupTopBar()
+        setupContent()
+        setupLoaderOverlay()
 
-        // Add button to the view
-        view.addSubview(createLinkButton)
+        let dismissTap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        // The buttons and fields below still receive their own touches
+        dismissTap.cancelsTouchesInView = false
+        view.addGestureRecognizer(dismissTap)
 
-        // Layout constraints
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(renderResults),
+            name: AppLinkResultStore.didChangeNotification, object: nil)
+        renderResults()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    // MARK: - Layout
+
+    private let topBar = UIView()
+
+    private func setupTopBar() {
+        topBar.backgroundColor = Palette.primaryContainer
+        topBar.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(topBar)
+
+        let titleLabel = UILabel()
+        titleLabel.text = "AppLink Demo"
+        titleLabel.textColor = .black
+        titleLabel.font = .systemFont(ofSize: 20, weight: .medium)
+        titleLabel.textAlignment = .center
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        topBar.addSubview(titleLabel)
+
         NSLayoutConstraint.activate([
-            createLinkButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            createLinkButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            createLinkButton.widthAnchor.constraint(equalToConstant: 200),
-            createLinkButton.heightAnchor.constraint(equalToConstant: 50),
+            topBar.topAnchor.constraint(equalTo: view.topAnchor),
+            topBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            topBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            topBar.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 56),
+
+            titleLabel.leadingAnchor.constraint(equalTo: topBar.leadingAnchor, constant: 16),
+            titleLabel.trailingAnchor.constraint(equalTo: topBar.trailingAnchor, constant: -16),
+            titleLabel.bottomAnchor.constraint(equalTo: topBar.bottomAnchor, constant: -12),
         ])
     }
 
-    @objc func createLinkTapped() {
+    private func setupContent() {
+        let scrollView = UIScrollView()
+        scrollView.backgroundColor = .white
+        scrollView.alwaysBounceVertical = true
+        // The scroll view already sits below the top bar, so it must not inset for the safe area
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scrollView)
 
-        //Help to get attribution information
-        appLinkService.getAttributionInfo { attributionInfo in
-            //Write code for handle attribution info
-        }
+        contentStack.axis = .vertical
+        contentStack.alignment = .fill
+        contentStack.spacing = 8
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(contentStack)
 
-        //Help to get referral information
-        appLinkService.getReferralInfo { referralInfo in
-            //Write code for handle referral info
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: topBar.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+
+            contentStack.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            contentStack.leadingAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            contentStack.trailingAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            contentStack.bottomAnchor.constraint(
+                equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -16),
+            contentStack.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+        ])
+
+        addSection(.deepLink)
+
+        addDivider()
+
+        addSection(.deprecatedListener)
+        addSection(.deprecatedApi)
+        addButton("Get Referral Details (Deprecated)", action: #selector(getReferralDetailsTapped))
+        addButton("Get Referral Info (Deprecated)", action: #selector(getReferralInfoTapped))
+
+        addDivider()
+
+        addSection(.attributionListener)
+        addSection(.attributionApi)
+        addButton("Get Attribution Info", action: #selector(getAttributionInfoTapped))
+
+        addDivider()
+
+        addSectionTitle("Create AppLink")
+        addTextField(nameField, label: "Name", text: "AppsOnAir")
+        addTextField(urlField, label: "URL", text: "https://appsonair.com")
+        // urlPrefix shouldn't contain http or https
+        addTextField(urlPrefixField, label: "URL Prefix", text: "")
+        addTextField(shortIdField, label: "Short ID", text: "")
+        addTextField(androidFallbackField, label: "Android Fallback URL", text: "")
+        addTextField(iosFallbackField, label: "iOS Fallback URL", text: "")
+        addTextField(
+            attributionTtlField, label: "Attribution TTL (seconds)", text: "",
+            keyboardType: .numberPad)
+        addTextViewField(
+            appsFlyerView, label: "AppsFlyer params (JSON, any keys allowed)",
+            text: defaultAppsFlyerJSON)
+
+        addSwitchRow(openInAndroidAppSwitch, label: "Open in Android App", isOn: true)
+        addSwitchRow(openInAndroidBrowserSwitch, label: "Open in Android Browser", isOn: false)
+        addSwitchRow(openInIosAppSwitch, label: "Open in iOS App", isOn: true)
+        addSwitchRow(openInAppleBrowserSwitch, label: "Open in iOS Browser", isOn: false)
+
+        addSection(.createLink)
+        addButton("Create Link", action: #selector(createLinkTapped))
+    }
+
+    private func setupLoaderOverlay() {
+        // Semi-transparent background that blocks all touch interactions
+        loaderOverlay.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+        loaderOverlay.isHidden = true
+        loaderOverlay.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(loaderOverlay)
+
+        activityIndicator.color = .blue
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        loaderOverlay.addSubview(activityIndicator)
+
+        NSLayoutConstraint.activate([
+            loaderOverlay.topAnchor.constraint(equalTo: view.topAnchor),
+            loaderOverlay.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            loaderOverlay.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            loaderOverlay.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            activityIndicator.centerXAnchor.constraint(equalTo: loaderOverlay.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: loaderOverlay.centerYAnchor),
+        ])
+    }
+
+    private func addSection(_ section: ResponseSection) {
+        let sectionView = ResponseSectionView(title: section.title)
+        sectionViews[section] = sectionView
+        contentStack.addArrangedSubview(sectionView)
+    }
+
+    private func addSectionTitle(_ title: String) {
+        let label = UILabel()
+        label.text = title
+        label.font = .systemFont(ofSize: 16, weight: .semibold)
+        label.textColor = .black
+        label.numberOfLines = 0
+        addRow(label, topInset: 12, bottomInset: 4)
+    }
+
+    private func addTextField(
+        _ field: UITextField, label: String, text: String,
+        keyboardType: UIKeyboardType = .default
+    ) {
+        field.text = text
+        field.placeholder = label
+        field.borderStyle = .roundedRect
+        field.font = .systemFont(ofSize: 14)
+        field.textColor = .black
+        field.keyboardType = keyboardType
+        field.autocapitalizationType = .none
+        field.autocorrectionType = .no
+        field.clearButtonMode = .whileEditing
+        addLabeledInput(label: label, input: field)
+    }
+
+    private func addTextViewField(_ textView: UITextView, label: String, text: String) {
+        textView.text = text
+        textView.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        textView.textColor = .black
+        // The outer scroll view handles scrolling, so the box grows to fit its content instead
+        textView.isScrollEnabled = false
+        textView.autocapitalizationType = .none
+        textView.autocorrectionType = .no
+        textView.layer.borderColor = UIColor.black.withAlphaComponent(0.2).cgColor
+        textView.layer.borderWidth = 1
+        textView.layer.cornerRadius = 6
+        textView.textContainerInset = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+        textView.heightAnchor.constraint(greaterThanOrEqualToConstant: 150).isActive = true
+        addLabeledInput(label: label, input: textView)
+    }
+
+    private func addSwitchRow(_ toggle: UISwitch, label: String, isOn: Bool) {
+        toggle.isOn = isOn
+        toggle.setContentHuggingPriority(.required, for: .horizontal)
+        toggle.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        let titleLabel = UILabel()
+        titleLabel.text = label
+        titleLabel.font = .systemFont(ofSize: 14)
+        titleLabel.textColor = .black
+        titleLabel.numberOfLines = 0
+
+        let stack = UIStackView(arrangedSubviews: [titleLabel, toggle])
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = 12
+        addRow(stack)
+    }
+
+    private func addLabeledInput(label: String, input: UIView) {
+        let titleLabel = UILabel()
+        titleLabel.text = label
+        titleLabel.font = .systemFont(ofSize: 13)
+        titleLabel.textColor = .black
+        titleLabel.numberOfLines = 0
+
+        let stack = UIStackView(arrangedSubviews: [titleLabel, input])
+        stack.axis = .vertical
+        stack.spacing = 4
+        addRow(stack)
+    }
+
+    /// Wraps a view in the 16pt horizontal gutter the sections use.
+    private func addRow(_ content: UIView, topInset: CGFloat = 4, bottomInset: CGFloat = 4) {
+        content.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = UIView()
+        container.addSubview(content)
+        NSLayoutConstraint.activate([
+            content.topAnchor.constraint(equalTo: container.topAnchor, constant: topInset),
+            content.bottomAnchor.constraint(
+                equalTo: container.bottomAnchor, constant: -bottomInset),
+            content.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            content.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+        ])
+        contentStack.addArrangedSubview(container)
+    }
+
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
+    }
+
+    private func addDivider() {
+        let divider = UIView()
+        divider.backgroundColor = UIColor.black.withAlphaComponent(0.12)
+        divider.translatesAutoresizingMaskIntoConstraints = false
+        divider.heightAnchor.constraint(equalToConstant: 1).isActive = true
+        contentStack.addArrangedSubview(divider)
+    }
+
+    private func addButton(_ title: String, action: Selector) {
+        let button = UIButton(type: .system)
+        button.setTitle(title, for: .normal)
+        button.setTitleColor(Palette.primary, for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 14, weight: .medium)
+        button.backgroundColor = Palette.buttonSurface
+        button.contentEdgeInsets = UIEdgeInsets(top: 10, left: 24, bottom: 10, right: 24)
+        button.layer.cornerRadius = 20
+        button.layer.shadowColor = UIColor.black.cgColor
+        button.layer.shadowOpacity = 0.15
+        button.layer.shadowOffset = CGSize(width: 0, height: 1)
+        button.layer.shadowRadius = 2
+        button.addTarget(self, action: action, for: .touchUpInside)
+        button.translatesAutoresizingMaskIntoConstraints = false
+
+        // Buttons are centered while the sections fill the width
+        let container = UIView()
+        container.addSubview(button)
+        NSLayoutConstraint.activate([
+            button.topAnchor.constraint(equalTo: container.topAnchor, constant: 6),
+            button.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -6),
+            button.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+        ])
+        contentStack.addArrangedSubview(container)
+    }
+
+    // MARK: - Rendering
+
+    @objc private func renderResults() {
+        for (section, sectionView) in sectionViews {
+            sectionView.value = AppLinkResultStore.shared[section]
         }
+    }
+
+    private func setLoading(_ isLoading: Bool) {
+        // `createAppLink` reports back on a background queue
+        DispatchQueue.main.async {
+            self.loaderOverlay.isHidden = !isLoading
+            if isLoading {
+                self.activityIndicator.startAnimating()
+            } else {
+                self.activityIndicator.stopAnimating()
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Deprecated, shown here only so its payload can be compared with `getAttributionInfo()`.
+    @objc private func getReferralDetailsTapped() {
         appLinkService.getReferralDetails { referralInfo in
-            //Write code for handle referral info
+            AppLinkResultStore.shared[.deprecatedApi] = responseText(referralInfo)
         }
+    }
+
+    /// Deprecated, shown here only so its payload can be compared with `getAttributionInfo()`.
+    @objc private func getReferralInfoTapped() {
+        appLinkService.getReferralInfo { referralInfo in
+            AppLinkResultStore.shared[.deprecatedApi] = responseText(referralInfo)
+        }
+    }
+
+    //Help to get attribution information
+    @objc private func getAttributionInfoTapped() {
+        appLinkService.getAttributionInfo { attributionInfo in
+            AppLinkResultStore.shared[.attributionApi] = responseText(attributionInfo)
+        }
+    }
+
+    @objc private func createLinkTapped() {
+        dismissKeyboard()
+
+        // Parsed before the call so malformed JSON is reported on its own rather than as an
+        // API failure.
+        var appsFlyer: [String: Any]?
+        let appsFlyerText = (appsFlyerView.text ?? "").trimmingCharacters(
+            in: .whitespacesAndNewlines)
+        if !appsFlyerText.isEmpty {
+            guard let data = appsFlyerText.data(using: .utf8),
+                let parsed = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+            else {
+                AppLinkResultStore.shared[.createLink] =
+                    "Invalid AppsFlyer JSON — fix the JSON and try again."
+                return
+            }
+            appsFlyer = parsed
+        }
+
+        setLoading(true)  // Show loader
 
         //help to set social meta
         let socialMeta = [
@@ -48,25 +387,85 @@ class ViewController: UIViewController {
             "description": "link description",
         ]
 
-        //help to set AppsFlyer attribution params
-        let appsFlyer: [String: Any] = [
-            "channel": "appsonair",
-            "campaignId": "01",
-            "campaign": "test",
-            "subs": ["sub1", "sub2", "sub3", "sub4", "sub5"],
-            "metaTitle": "metaTitle",
-            "metaDescription": "metaDescription",
-        ]
-
         //help to create appLink
         // <urlPrefix> shouldn't contain http or https
         appLinkService.createAppLink(
-            url: "https://appsonair.com", name: "AppsOnAir",
-            urlPrefix: "YOUR_DOMAIN_NAME", shortId: "LINK_ID",
-            socialMeta: socialMeta, isOpenInBrowserApple: false, isOpenInIosApp: true,
-            iosFallbackUrl: "https://appstore.com", appsFlyer: appsFlyer, attributionTtl: 3600
-        ) { linkInfo in
-            //write code for handle create link
+            url: text(urlField), name: text(nameField),
+            urlPrefix: text(urlPrefixField),
+            shortId: text(shortIdField).isEmpty ? nil : text(shortIdField),
+            socialMeta: socialMeta,
+            isOpenInBrowserApple: openInAppleBrowserSwitch.isOn,
+            isOpenInIosApp: openInIosAppSwitch.isOn,
+            iosFallbackUrl: text(iosFallbackField),
+            isOpenInAndroidApp: openInAndroidAppSwitch.isOn,
+            isOpenInBrowserAndroid: openInAndroidBrowserSwitch.isOn,
+            androidFallbackUrl: text(androidFallbackField),
+            appsFlyer: appsFlyer,
+            attributionTtl: Int(text(attributionTtlField))
+        ) { [weak self] linkInfo in
+            print("API response==> \(linkInfo)")
+            AppLinkResultStore.shared[.createLink] = responseText(linkInfo)
+            self?.setLoading(false)  // Hide loader
         }
+    }
+
+    private func text(_ field: UITextField) -> String {
+        (field.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+// MARK: - Supporting views
+
+/// Approximates the Material 3 light color scheme used by the Android sample.
+private enum Palette {
+    static let primary = UIColor(red: 0.40, green: 0.31, blue: 0.64, alpha: 1)
+    static let primaryContainer = UIColor(red: 0.92, green: 0.87, blue: 1.00, alpha: 1)
+    static let buttonSurface = UIColor(red: 0.97, green: 0.95, blue: 0.98, alpha: 1)
+}
+
+/// A titled panel showing the latest response for one part of the SDK.
+private final class ResponseSectionView: UIView {
+    private let valueView = UITextView()
+
+    var value: String = "" {
+        didSet { valueView.text = value.isEmpty ? "No data yet" : value }
+    }
+
+    init(title: String) {
+        super.init(frame: .zero)
+
+        let titleLabel = UILabel()
+        titleLabel.text = title
+        titleLabel.font = .boldSystemFont(ofSize: 14)
+        titleLabel.textColor = .black
+        titleLabel.numberOfLines = 0
+
+        // Selectable so the response can be selected and copied off the device
+        valueView.isEditable = false
+        valueView.isScrollEnabled = false
+        valueView.isSelectable = true
+        valueView.backgroundColor = .clear
+        valueView.textContainerInset = .zero
+        valueView.textContainer.lineFragmentPadding = 0
+        valueView.font = .systemFont(ofSize: 12)
+        valueView.textColor = .black
+        valueView.text = "No data yet"
+
+        let stack = UIStackView(arrangedSubviews: [titleLabel, valueView])
+        stack.axis = .vertical
+        stack.spacing = 4
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 }

--- a/README.md
+++ b/README.md
@@ -299,6 +299,19 @@ Objective-C++
 #import "AppsOnAir-AppLink/AppLinkService.h"
 ```
 
+### `appsFlyer` Parameters
+
+*(Optional)* Pass this dictionary to `createAppLink` to attach AppsFlyer attribution data to the generated link.
+
+| Key | Type | Required | Description |
+|---|---|---|---|
+| `channel` | String | Optional | The media source / channel driving traffic to this link (e.g. `"appsonair"`). |
+| `campaignId` | String | Optional | Unique identifier for the marketing campaign. |
+| `campaign` | String | Optional | Human-readable name of the marketing campaign. |
+| `subs` | [String] | Optional | Sub-parameters for granular tracking (e.g. `["sub1", "sub2", "sub3", "sub4", "sub5"]`). |
+| `metaTitle` | String | Optional | Title used for attribution metadata. |
+| `metaDescription` | String | Optional | Description used for attribution metadata. |
+
 ### App-Link Implement Code
 
 Swift UI
@@ -324,6 +337,14 @@ struct ContentView: View {
                     isOpenInBrowserApple: false,
                     isOpenInIosApp: true,
                     iosFallbackUrl: "https://appstore.com",
+                    appsFlyer: [ // Optional: AppsFlyer attribution params
+                        "channel": "appsonair",
+                        "campaignId": "01",
+                        "campaign": "test",
+                        "subs": ["sub1", "sub2", "sub3", "sub4", "sub5"],
+                        "metaTitle": "metaTitle",
+                        "metaDescription": "metaDescription"
+                    ]
                 ) { linkInfo in
                      //Write the code for handling create link
                 }
@@ -374,7 +395,7 @@ class ViewController: UIViewController {
                // Help to create the link
                // <urlPrefix> shouldn't contain http or https
                // <shortId>  If not set, it will be auto-generated
-               AppLinkService.shared.createAppLink(url: "https://appsonair.com",name: "AppsOnAir",urlPrefix: "YOUR_DOMAIN_NAME",shortId: "LINK_ID",socialMeta: ["title": "link title","description":  "link description","imageUrl": "https://image.png"],isOpenInBrowserApple: false,isOpenInIosApp: true,iosFallbackUrl: "https://appstore.com"
+               AppLinkService.shared.createAppLink(url: "https://appsonair.com",name: "AppsOnAir",urlPrefix: "YOUR_DOMAIN_NAME",shortId: "LINK_ID",socialMeta: ["title": "link title","description":  "link description","imageUrl": "https://image.png"],isOpenInBrowserApple: false,isOpenInIosApp: true,iosFallbackUrl: "https://appstore.com",appsFlyer: ["channel": "appsonair","campaignId": "01","campaign": "test","subs": ["sub1", "sub2", "sub3", "sub4", "sub5"],"metaTitle": "metaTitle","metaDescription": "metaDescription"]
         ) { linkInfo  in
                     //Write the code for handling create link
                 }
@@ -424,7 +445,7 @@ Objective-C
      // Help to create link
      // <urlPrefix> shouldn't contain http or https
      // <shortId>  If not set, it will be auto-generated
-    [self.appLinkService createAppLinkWithUrl:@"https://appsonair.com" name:@"AppsOnAir" urlPrefix:@"YOUR_DOMAIN_NAME" shortId: @"LINK_ID"socialMeta:@{@"title":@"link title",@"description":@"link description",@"imageUrl":@"https://image.png"}isOpenInBrowserApple:@0 isOpenInIosApp:@1 iosFallbackUrl:@"https://appstore.com" isOpenInAndroidApp:@1 isOpenInBrowserAndroid:@0 androidFallbackUrl:@"https://play.google.com"completion:^(NSDictionary<NSString *,id> * linkInfo) {
+    [self.appLinkService createAppLinkWithUrl:@"https://appsonair.com" name:@"AppsOnAir" urlPrefix:@"YOUR_DOMAIN_NAME" shortId: @"LINK_ID"socialMeta:@{@"title":@"link title",@"description":@"link description",@"imageUrl":@"https://image.png"}isOpenInBrowserApple:@0 isOpenInIosApp:@1 iosFallbackUrl:@"https://appstore.com" isOpenInAndroidApp:@1 isOpenInBrowserAndroid:@0 androidFallbackUrl:@"https://play.google.com"appsFlyer:@{@"channel":@"appsonair",@"campaignId":@"01",@"campaign":@"test",@"subs":@[@"sub1",@"sub2",@"sub3",@"sub4",@"sub5"],@"metaTitle":@"metaTitle",@"metaDescription":@"metaDescription"} completion:^(NSDictionary<NSString *,id> * linkInfo) {
         //Write the code for handling create link
     }];
 }
@@ -446,7 +467,7 @@ Objective-C++
 
   self.appLinkServices = [AppLinkServices shared];
 
-  [self.appLinkServices createAppLinkWithUrl:@"https://appsonair.com" name:@"AppsOnAir" urlPrefix:@"YOUR_DOMAIN_NAME" shortId: @"LINK_ID" socialMeta:@{@"title":@"link title",@"description":@"link description",@"imageUrl":@"https://image.png"}isOpenInBrowserApple:@0 isOpenInIosApp:@1 iosFallbackUrl:@"https://appstore.com" isOpenInAndroidApp:@1 isOpenInBrowserAndroid:@0 androidFallbackUrl:@"https://play.google.com" completion:^(NSDictionary<NSString*,id> * linkInfo) {
+  [self.appLinkServices createAppLinkWithUrl:@"https://appsonair.com" name:@"AppsOnAir" urlPrefix:@"YOUR_DOMAIN_NAME" shortId: @"LINK_ID" socialMeta:@{@"title":@"link title",@"description":@"link description",@"imageUrl":@"https://image.png"}isOpenInBrowserApple:@0 isOpenInIosApp:@1 iosFallbackUrl:@"https://appstore.com" isOpenInAndroidApp:@1 isOpenInBrowserAndroid:@0 androidFallbackUrl:@"https://play.google.com" appsFlyer:@{@"channel":@"appsonair",@"campaignId":@"01",@"campaign":@"test",@"subs":@[@"sub1",@"sub2",@"sub3",@"sub4",@"sub5"],@"metaTitle":@"metaTitle",@"metaDescription":@"metaDescription"} completion:^(NSDictionary<NSString*,id> * linkInfo) {
     //Write the code for handling create link
     }];
   return [super application:application didFinishLaunchingWithOptions:launchOptions];

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - ✅ Fallback behavior (e.g., open App Store)
 - ✅ Custom domain support
 - ✅ Referral tracking
+- ✅ AppsFlyer attribution params (`appsFlyer`) and attribution TTL (`attributionTtl`) on link creation
 - ✅ Seamless migration from Firebase Dynamic Links to AppLink
 
 **Note:** For comprehensive instructions on migrating Firebase Dynamic Links to AppLink, refer to the [documentation](https://documentation.appsonair.com/MobileQuickstart/AppLink/firebase-dynamiclinks-migration).
@@ -242,10 +243,10 @@ Objective-C
     self.appLinkServices = [AppLinkService shared];
     
     // Help to initialize link services
-    [self.appLinkServices initializeOnDeepLinkProcessed:^(NSURL * url, NSDictionary<NSString *,id> * linkInfo) {
-        //Write the code for handling flow based on url
+    [self.appLinkServices initializeOnDeepLinkProcessed:^(NSURL * url, NSDictionary<NSString *,id> * linkInfo){
+          //Write the code for handling flow based on url
     } onAttributionListener:^(NSDictionary<NSString *,id> * attributionInfo) {
-        //Write the code for handling attribution flow
+       //Write the code for handling attribution flow
     }];
     // Override point for customization after application launch.
     return YES;
@@ -318,6 +319,10 @@ Objective-C++
 | `metaTitle` | String | Optional | Title used for attribution metadata. |
 | `metaDescription` | String | Optional | Description used for attribution metadata. |
 
+### `attributionTtl` Parameter
+
+*(Optional)* `Int` — time-to-live, in seconds, for attribution of the generated link (e.g. `60` for 60 seconds).
+
 ### App-Link Implement Code
 
 Swift UI
@@ -350,7 +355,8 @@ struct ContentView: View {
                         "subs": ["sub1", "sub2", "sub3", "sub4", "sub5"],
                         "metaTitle": "metaTitle",
                         "metaDescription": "metaDescription"
-                    ]
+                    ],
+                    attributionTtl: 60 // Optional: TTL (in seconds) for attribution
                 ) { linkInfo in
                      //Write the code for handling create link
                 }
@@ -401,7 +407,7 @@ class ViewController: UIViewController {
                // Help to create the link
                // <urlPrefix> shouldn't contain http or https
                // <shortId>  If not set, it will be auto-generated
-               AppLinkService.shared.createAppLink(url: "https://appsonair.com",name: "AppsOnAir",urlPrefix: "YOUR_DOMAIN_NAME",shortId: "LINK_ID",socialMeta: ["title": "link title","description":  "link description","imageUrl": "https://image.png"],isOpenInBrowserApple: false,isOpenInIosApp: true,iosFallbackUrl: "https://appstore.com",appsFlyer: ["channel": "appsonair","campaignId": "01","campaign": "test","subs": ["sub1", "sub2", "sub3", "sub4", "sub5"],"metaTitle": "metaTitle","metaDescription": "metaDescription"]
+               AppLinkService.shared.createAppLink(url: "https://appsonair.com",name: "AppsOnAir",urlPrefix: "YOUR_DOMAIN_NAME",shortId: "LINK_ID",socialMeta: ["title": "link title","description":  "link description","imageUrl": "https://image.png"],isOpenInBrowserApple: false,isOpenInIosApp: true,iosFallbackUrl: "https://appstore.com",appsFlyer: ["channel": "appsonair","campaignId": "01","campaign": "test","subs": ["sub1", "sub2", "sub3", "sub4", "sub5"],"metaTitle": "metaTitle","metaDescription": "metaDescription"],attributionTtl: 60
         ) { linkInfo  in
                     //Write the code for handling create link
                 }
@@ -451,7 +457,7 @@ Objective-C
      // Help to create link
      // <urlPrefix> shouldn't contain http or https
      // <shortId>  If not set, it will be auto-generated
-    [self.appLinkService createAppLinkWithUrl:@"https://appsonair.com" name:@"AppsOnAir" urlPrefix:@"YOUR_DOMAIN_NAME" shortId: @"LINK_ID"socialMeta:@{@"title":@"link title",@"description":@"link description",@"imageUrl":@"https://image.png"}isOpenInBrowserApple:@0 isOpenInIosApp:@1 iosFallbackUrl:@"https://appstore.com" isOpenInAndroidApp:@1 isOpenInBrowserAndroid:@0 androidFallbackUrl:@"https://play.google.com"appsFlyer:@{@"channel":@"appsonair",@"campaignId":@"01",@"campaign":@"test",@"subs":@[@"sub1",@"sub2",@"sub3",@"sub4",@"sub5"],@"metaTitle":@"metaTitle",@"metaDescription":@"metaDescription"} completion:^(NSDictionary<NSString *,id> * linkInfo) {
+    [self.appLinkService createAppLinkWithUrl:@"https://appsonair.com" name:@"AppsOnAir" urlPrefix:@"YOUR_DOMAIN_NAME" shortId: @"LINK_ID"socialMeta:@{@"title":@"link title",@"description":@"link description",@"imageUrl":@"https://image.png"}isOpenInBrowserApple:@0 isOpenInIosApp:@1 iosFallbackUrl:@"https://appstore.com" isOpenInAndroidApp:@1 isOpenInBrowserAndroid:@0 androidFallbackUrl:@"https://play.google.com"appsFlyer:@{@"channel":@"appsonair",@"campaignId":@"01",@"campaign":@"test",@"subs":@[@"sub1",@"sub2",@"sub3",@"sub4",@"sub5"],@"metaTitle":@"metaTitle",@"metaDescription":@"metaDescription"} attributionTtl:@60 completion:^(NSDictionary<NSString *,id> * linkInfo) {
         //Write the code for handling create link
     }];
 }
@@ -473,7 +479,7 @@ Objective-C++
 
   self.appLinkServices = [AppLinkService shared];
 
-  [self.appLinkServices createAppLinkWithUrl:@"https://appsonair.com" name:@"AppsOnAir" urlPrefix:@"YOUR_DOMAIN_NAME" shortId: @"LINK_ID" socialMeta:@{@"title":@"link title",@"description":@"link description",@"imageUrl":@"https://image.png"}isOpenInBrowserApple:@0 isOpenInIosApp:@1 iosFallbackUrl:@"https://appstore.com" isOpenInAndroidApp:@1 isOpenInBrowserAndroid:@0 androidFallbackUrl:@"https://play.google.com" appsFlyer:@{@"channel":@"appsonair",@"campaignId":@"01",@"campaign":@"test",@"subs":@[@"sub1",@"sub2",@"sub3",@"sub4",@"sub5"],@"metaTitle":@"metaTitle",@"metaDescription":@"metaDescription"} completion:^(NSDictionary<NSString*,id> * linkInfo) {
+  [self.appLinkServices createAppLinkWithUrl:@"https://appsonair.com" name:@"AppsOnAir" urlPrefix:@"YOUR_DOMAIN_NAME" shortId: @"LINK_ID" socialMeta:@{@"title":@"link title",@"description":@"link description",@"imageUrl":@"https://image.png"}isOpenInBrowserApple:@0 isOpenInIosApp:@1 iosFallbackUrl:@"https://appstore.com" isOpenInAndroidApp:@1 isOpenInBrowserAndroid:@0 androidFallbackUrl:@"https://play.google.com" appsFlyer:@{@"channel":@"appsonair",@"campaignId":@"01",@"campaign":@"test",@"subs":@[@"sub1",@"sub2",@"sub3",@"sub4",@"sub5"],@"metaTitle":@"metaTitle",@"metaDescription":@"metaDescription"} attributionTtl:@60 completion:^(NSDictionary<NSString*,id> * linkInfo) {
     //Write the code for handling create link
     }];
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
@@ -517,6 +523,7 @@ struct ContentView: View {
                    //Write the code for handling attribution flow
                 }
             }) {
+
                 Text("Fetch Attribution Info")
                     .padding()
                     .frame(maxWidth: .infinity)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ## [![pub package](https://appsonair.com/images/logo.svg)](https://cocoapods.org/pods/AppsOnAir-AppLink)
 # AppsOnAir-AppLink
 
-[![CI Status](https://img.shields.io/travis/164989979/AppsOnAir-AppLink.svg?style=flat)](https://travis-ci.org/164989979/AppsOnAir-AppLink)
 [![Version](https://img.shields.io/cocoapods/v/AppsOnAir-AppLink.svg?style=flat)](https://cocoapods.org/pods/AppsOnAir-AppLink)
 [![License](https://img.shields.io/cocoapods/l/AppsOnAir-AppLink.svg?style=flat)](https://cocoapods.org/pods/AppsOnAir-AppLink)
 [![Platform](https://img.shields.io/cocoapods/p/AppsOnAir-AppLink.svg?style=flat)](https://cocoapods.org/pods/AppsOnAir-AppLink)
@@ -64,7 +63,7 @@ If you are integrating AppsOnAir-AppLink into another Swift package, add it to t
 dependencies: [
     .package(
         url: "https://github.com/apps-on-air/AppsOnAir-iOS-AppLink.git",
-        from: "1.4.1"
+        from: "2.0.0"
     )
 ]
 ```
@@ -245,7 +244,8 @@ Objective-C
     // Help to initialize link services
     [self.appLinkServices initializeOnDeepLinkProcessed:^(NSURL * url, NSDictionary<NSString *,id> * linkInfo){
           //Write the code for handling flow based on url
-    } onAttributionListener:^(NSDictionary<NSString *,id> * attributionInfo) {
+    } onReferralLinkDetected:nil
+        onAttributionListener:^(NSDictionary<NSString *,id> * attributionInfo) {
        //Write the code for handling attribution flow
     }];
     // Override point for customization after application launch.
@@ -272,7 +272,8 @@ Objective-C++
 
   [self.appLinkServices initializeOnDeepLinkProcessed:^(NSURL * _Nullable url, NSDictionary * _Nonnull linkInfo) {
       //Write the code for handling flow based on url
-  } onAttributionListener:^(NSDictionary * _Nonnull attributionInfo) {
+  } onReferralLinkDetected:nil
+      onAttributionListener:^(NSDictionary * _Nonnull attributionInfo) {
       //Write the code for handling attribution flow
   }];
   
@@ -281,11 +282,17 @@ Objective-C++
 
 ```
 
-`onAttributionListener()` fires at most twice: once when the attribution is first detected, and
-once more on the return to the foreground that follows `isFirstLaunch` turning `false`, so the
-payload carries that flip. Later foreground returns are silent — they would only repeat the same
-persisted state. Gate any one time logic on `isFirstLaunch` rather than on the callback firing.
-The payload is the same one [`getAttributionInfo()`](#3-retrieving-the-attribution-info) returns.
+`initialize` takes a single signature, with both listeners optional:
+
+```swift
+initialize(
+    onDeepLinkProcessed: (URL?, [String: Any]) -> Void,
+    onReferralLinkDetected: (([String: Any]) -> Void)? = nil,
+    onAttributionListener: (([String: Any]) -> Void)? = nil
+)
+```
+
+
 
 ## 2. Creating the AppLink 
 You can also create link, such as from a button action:
@@ -322,6 +329,7 @@ Objective-C++
 ### `attributionTtl` Parameter
 
 *(Optional)* `Int` — time-to-live, in seconds, for attribution of the generated link (e.g. `60` for 60 seconds).
+
 
 ### App-Link Implement Code
 
@@ -649,11 +657,13 @@ following keys inside the `data` object of the response:
 
 | Response Key | Type | Description |
 | --- | --- | --- |
-| `isFirstLaunch` | Bool | `true` only during the very first app launch after installation. It turns `false` as soon as the app leaves the foreground (backgrounded or phone locked) and stays `false` on every later launch. |
-| `firstInstallTime` | Int64 | Timestamp (epoch milliseconds) of the app's first installation, derived from the app's Documents directory creation date. Computed locally, so it is always available. |
-| `isConsumed` | Bool | `true` once a referral fetch has returned successfully for this install. Persisted, so it stays `true` on every later launch. |
-| `attributionStatus` | String | `non-organic` when the install happened within `attributionTtl` seconds of the click, otherwise `organic`. A referral that was found but could not be timed — no click time, no `attributionTtl` in the response, or no install time — stays `non-organic`. Resolved once and restored from storage on later launches. |
-| `applink_click_time` | Int64 | Timestamp (epoch milliseconds) of the click. Only present when the Advanced Deferred AppLink feature is enabled and the link carries the parameter, since the clipboard is the only source for it on iOS. |
+| `isFirstLaunch` | Bool | `true` only during the very first app launch after installation.|
+| `firstInstallTime` | Int64 | Timestamp (epoch milliseconds) of the app's first installation.|
+| `isConsumed` | Bool | `true` once a referral fetch has returned successfully for this install. Persisted. |
+| `attributionStatus` | String | `non-organic` when the install happened within `attributionTtl` of the click, otherwise `organic`. |
+| `applink_click_time` | Int64 | Timestamp (epoch milliseconds) of the click. |
+
+
 
 ### Deprecated APIs
 
@@ -662,10 +672,19 @@ integrations keep working, but should migrate:
 
 | Deprecated | Use instead |
 | --- | --- |
-| `initialize(onDeepLinkProcessed:onReferralLinkDetected:)` | `initialize(onDeepLinkProcessed:onAttributionListener:)` |
 | `onReferralLinkDetected()` | `onAttributionListener()` |
 | `getReferralInfo()` | `getAttributionInfo()` |
 | `getReferralDetails()` | `getAttributionInfo()` |
+
+The deprecated getters carry the **referral payload only**. None of `appsFlyer`, `isFirstLaunch`,
+`firstInstallTime`, `isConsumed`, `attributionStatus` or `applink_click_time` appear in them —
+those belong to `getAttributionInfo()` and `onAttributionListener()`. `attributionTtl` expiry
+still applies to all three getters.
+
+`onReferralLinkDetected` is still a parameter of `initialize`, so it no longer raises a deprecation
+warning at the call site the way the removed overload did. It remains detection-only: it fires when
+a referral fetch actually runs — first open, or no referral cached yet — and is not re-delivered on
+the foreground return that follows `isFirstLaunch` turning `false`.
 
 ## Troubleshooting
 
@@ -730,6 +749,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 @property (nonatomic, strong) AppLinkService *appLinkServices;
 @end
 
+@implementation AppDelegate
+
 - (BOOL)application:(UIApplication * )application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     self.appLinkServices = [AppLinkService shared];
     return YES;
@@ -755,9 +776,10 @@ continueUserActivity:(NSUserActivity *)userActivity
     return NO;
 }
 
+@end
 ```
 
-**SceneDelegatee.m**
+**SceneDelegate.m**
 
 ```swift
 #import "SceneDelegate.h"
@@ -844,7 +866,7 @@ willConnectToSession:(UISceneSession *)session
             openURL:(NSURL *)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
 
-  [self.appLinkServices handleAppLinkWithURL:url];
+  [self.appLinkServices handleAppLinkWithIncomingURL:url];
   
     return YES;
 }
@@ -855,7 +877,7 @@ continueUserActivity:(NSUserActivity *)userActivity
 
     if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
         NSURL *url = userActivity.webpageURL;
-        [self.appLinkServices handleAppLinkWithURL:url];
+        [self.appLinkServices handleAppLinkWithIncomingURL:url];
     }
     return NO;
 }

--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         AppLinkService.shared.initialize { url, linkInfo in
             //Write the code for handling flow based on url
-        }onReferralLinkDetected: { referralInfo in
-            //Write the code for handling referral flow based on url
+        } onAttributionListener: { attributionInfo in
+            //Write the code for handling attribution flow
         }
       return true
   }
@@ -216,8 +216,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Help to initialize link services
         AppLinkService.shared.initialize { url, linkInfo in
             //Write the code for handling flow based on url
-        } onReferralLinkDetected: { referralInfo in
-            //Write the code for handling referral flow based on url
+        } onAttributionListener: { attributionInfo in
+            //Write the code for handling attribution flow
         }
         return true
     }
@@ -244,8 +244,8 @@ Objective-C
     // Help to initialize link services
     [self.appLinkServices initializeOnDeepLinkProcessed:^(NSURL * url, NSDictionary<NSString *,id> * linkInfo) {
         //Write the code for handling flow based on url
-    } onReferralLinkDetected:^(NSDictionary<NSString *,id> * referralInfo) {
-        //Write the code for handling referral flow based on url
+    } onAttributionListener:^(NSDictionary<NSString *,id> * attributionInfo) {
+        //Write the code for handling attribution flow
     }];
     // Override point for customization after application launch.
     return YES;
@@ -260,25 +260,31 @@ Objective-C++
 #import "AppsOnAir-AppLink/AppLinkService.h"
 
 @interface AppDelegate ()
-@property (nonatomic, strong)  AppLinkServices *appLinkServices;
+@property (nonatomic, strong)  AppLinkService *appLinkServices;
 @end
 
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  self.appLinkServices = [AppLinkServices shared];
+  self.appLinkServices = [AppLinkService shared];
 
-  [self.appLinkServices initializeWithOnDeepLinkProcessed:^(NSURL * _Nullable url, NSDictionary * _Nonnull linkInfo) {
+  [self.appLinkServices initializeOnDeepLinkProcessed:^(NSURL * _Nullable url, NSDictionary * _Nonnull linkInfo) {
       //Write the code for handling flow based on url
-  } onReferralLinkDetected:^(NSDictionary * _Nonnull referralInfo) {
-      //Write the code for handling referral flow based on url
+  } onAttributionListener:^(NSDictionary * _Nonnull attributionInfo) {
+      //Write the code for handling attribution flow
   }];
   
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 
 ```
+
+`onAttributionListener()` fires at most twice: once when the attribution is first detected, and
+once more on the return to the foreground that follows `isFirstLaunch` turning `false`, so the
+payload carries that flip. Later foreground returns are silent — they would only repeat the same
+persisted state. Gate any one time logic on `isFirstLaunch` rather than on the callback firing.
+The payload is the same one [`getAttributionInfo()`](#3-retrieving-the-attribution-info) returns.
 
 ## 2. Creating the AppLink 
 You can also create link, such as from a button action:
@@ -457,7 +463,7 @@ Objective-C++
 #import "AppsOnAir-AppLink/AppLinkService.h"
 
 @interface AppDelegate ()
-@property (nonatomic, strong)  AppLinkServices *appLinkServices;
+@property (nonatomic, strong)  AppLinkService *appLinkServices;
 @end
 
 @implementation AppDelegate
@@ -465,7 +471,7 @@ Objective-C++
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
 
-  self.appLinkServices = [AppLinkServices shared];
+  self.appLinkServices = [AppLinkService shared];
 
   [self.appLinkServices createAppLinkWithUrl:@"https://appsonair.com" name:@"AppsOnAir" urlPrefix:@"YOUR_DOMAIN_NAME" shortId: @"LINK_ID" socialMeta:@{@"title":@"link title",@"description":@"link description",@"imageUrl":@"https://image.png"}isOpenInBrowserApple:@0 isOpenInIosApp:@1 iosFallbackUrl:@"https://appstore.com" isOpenInAndroidApp:@1 isOpenInBrowserAndroid:@0 androidFallbackUrl:@"https://play.google.com" appsFlyer:@{@"channel":@"appsonair",@"campaignId":@"01",@"campaign":@"test",@"subs":@[@"sub1",@"sub2",@"sub3",@"sub4",@"sub5"],@"metaTitle":@"metaTitle",@"metaDescription":@"metaDescription"} completion:^(NSDictionary<NSString*,id> * linkInfo) {
     //Write the code for handling create link
@@ -475,8 +481,8 @@ Objective-C++
 ```
 
 
-## 3. To Retrieving Referral Link  
-You can also retrieving linkInfo, such as from a button action:
+## 3. Retrieving the attribution info
+You can also retrieve the attribution info on demand, such as from a button action:
 ### Firstly, import AppsOnAir_AppLink in your ViewController file or swift code file
 
 Swift / SwiftUI
@@ -507,11 +513,11 @@ struct ContentView: View {
     var body: some View {
         VStack(spacing: 20) {
             Button(action: {
-                AppLinkService.shared.getReferralInfo { linkInfo in
-                   //Write the code for handling referral flow based on url
+                AppLinkService.shared.getAttributionInfo { attributionInfo in
+                   //Write the code for handling attribution flow
                 }
             }) {
-                Text("Fetch Referral Link")
+                Text("Fetch Attribution Info")
                     .padding()
                     .frame(maxWidth: .infinity)
                     .background(Color.green)
@@ -554,9 +560,9 @@ class ViewController: UIViewController {
     
           // Define the action when button is pressed
            @objc func buttonPressed() {
-                // Help to retrieving referral linkInfo
-                AppLinkService.shared.getReferralInfo { linkInfo in
-                   //Write the code for handling referral linkInfo
+                // Help to retrieving the attribution info
+                AppLinkService.shared.getAttributionInfo { attributionInfo in
+                   //Write the code for handling attribution info
                 }
            }
 
@@ -589,7 +595,7 @@ Objective-C
        UIButton *ctaButton = [UIButton buttonWithType:UIButtonTypeSystem];
        
        // Set button title
-       [ctaButton setTitle:@"Fetch Referral Link" forState:UIControlStateNormal];
+       [ctaButton setTitle:@"Fetch Attribution Info" forState:UIControlStateNormal];
        
        // Set button frame (position and size)
        ctaButton.frame = CGRectMake(100, 200, 200, 50);
@@ -601,9 +607,9 @@ Objective-C
        [self.view addSubview:ctaButton];
 }
 - (void)openNextScreen {
-    // Help to retrieving referral linkInfo
-    [self.appLinkServices getReferralInfoWithCompletion:^(NSDictionary<NSString *,id> * linkInfo) {
-         //Write the code for handling referral linkInfo
+    // Help to retrieving the attribution info
+    [self.appLinkService getAttributionInfoWithCompletion:^(NSDictionary<NSString *,id> * attributionInfo) {
+         //Write the code for handling attribution info
     }];
 }
 ```
@@ -614,22 +620,45 @@ Objective-C++
 #import "AppsOnAir-AppLink/AppLinkService.h"
 
 @interface AppDelegate ()
-@property (nonatomic, strong)  AppLinkServices *appLinkServices;
+@property (nonatomic, strong)  AppLinkService *appLinkServices;
 @end
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
 
-  self.appLinkServices = [AppLinkServices shared];
+  self.appLinkServices = [AppLinkService shared];
 
-  [self.appLinkServices getReferralInfoWithCompletion:^(NSDictionary * _Nonnull linkInfo) {
-      //Write the code for handling referral linkInfo
+  [self.appLinkServices getAttributionInfoWithCompletion:^(NSDictionary * _Nonnull attributionInfo) {
+      //Write the code for handling attribution info
   }];
 
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 ```
+
+Along with the referral details, `getAttributionInfo()` and `onAttributionListener()` add the
+following keys inside the `data` object of the response:
+
+| Response Key | Type | Description |
+| --- | --- | --- |
+| `isFirstLaunch` | Bool | `true` only during the very first app launch after installation. It turns `false` as soon as the app leaves the foreground (backgrounded or phone locked) and stays `false` on every later launch. |
+| `firstInstallTime` | Int64 | Timestamp (epoch milliseconds) of the app's first installation, derived from the app's Documents directory creation date. Computed locally, so it is always available. |
+| `isConsumed` | Bool | `true` once a referral fetch has returned successfully for this install. Persisted, so it stays `true` on every later launch. |
+| `attributionStatus` | String | `non-organic` when the install happened within `attributionTtl` seconds of the click, otherwise `organic`. A referral that was found but could not be timed — no click time, no `attributionTtl` in the response, or no install time — stays `non-organic`. Resolved once and restored from storage on later launches. |
+| `applink_click_time` | Int64 | Timestamp (epoch milliseconds) of the click. Only present when the Advanced Deferred AppLink feature is enabled and the link carries the parameter, since the clipboard is the only source for it on iOS. |
+
+### Deprecated APIs
+
+The following APIs are deprecated and will be removed in a future release. Existing
+integrations keep working, but should migrate:
+
+| Deprecated | Use instead |
+| --- | --- |
+| `initialize(onDeepLinkProcessed:onReferralLinkDetected:)` | `initialize(onDeepLinkProcessed:onAttributionListener:)` |
+| `onReferralLinkDetected()` | `onAttributionListener()` |
+| `getReferralInfo()` | `getAttributionInfo()` |
+| `getReferralDetails()` | `getAttributionInfo()` |
 
 ## Troubleshooting
 
@@ -791,7 +820,7 @@ willConnectToSession:(UISceneSession *)session
 #import "AppsOnAir-AppLink/AppLinkService.h"
 
 @interface AppDelegate ()
-@property (nonatomic, strong)  AppLinkServices *appLinkServices;
+@property (nonatomic, strong)  AppLinkService *appLinkServices;
 @end
 
 @implementation AppDelegate
@@ -799,7 +828,7 @@ willConnectToSession:(UISceneSession *)session
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   
-  self.appLinkServices = [AppLinkServices shared];
+  self.appLinkServices = [AppLinkService shared];
   
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }


### PR DESCRIPTION
## 2.0.0

* `getReferralInfo()` is now deprecated, use `getAttributionInfo()` instead.

* Introduced `getAttributionInfo()` method.
    * Returns the same data as `getReferralInfo()` with additional `isFirstLaunch`, `firstInstallTime`, `isConsumed` and `attributionStatus` fields included in the response.

* Introduced `onAttributionListener()` listener.
    * When an attribution is detected, and again every time the app returns to the foreground so the payload stays current.

* Added `appsFlyer` and `attributionTtl` params to `AppLinkParams` for AppsFlyer attribution support in `createAppLink` method.

**Deprecated:**

* `onReferralLinkDetected()` — use `onAttributionListener()`.
* `getReferralInfo()` and `getReferralDetails()` — use `getAttributionInfo()`.